### PR TITLE
Update codecov config with new github org

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -28,4 +28,4 @@ jobs:
           file: .build/cover.out
           exclude: ./
           token: ${{ secrets.CODECOV_TOKEN }}
-          slug: uber-go/cadence-client
+          slug: cadence-workflow/cadence-go-client

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -1,5 +1,6 @@
 name: Workflow for Codecov integration
 on: [push, pull_request]
+
 jobs:
   codecov:
     runs-on: ubuntu-latest

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -1,6 +1,5 @@
 name: Workflow for Codecov integration
 on: [push, pull_request]
-
 jobs:
   codecov:
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Repo has moved from `uber-go/cadence-client` to `cadence-workflow/cadence-go-client`
