### PR TITLE
[cadence/debug] Update polletracker to support poller type breakdown

### DIFF
--- a/internal/common/debug/types.go
+++ b/internal/common/debug/types.go
@@ -34,9 +34,9 @@ type (
 	PollerTracker interface {
 		// Start collects information on poller start up.
 		// consumers should provide a concurrency-safe implementation.
-		Start() Stopper
+		Start(workerType string) Stopper
 		// Stats return the number or running pollers
-		Stats() int32
+		Stats() Pollers
 	}
 
 	// WorkerStats provides a set of methods that can be used to collect
@@ -67,6 +67,11 @@ type (
 	// Deprecated: in development and very likely to change
 	Activities []struct {
 		Info  ActivityInfo
+		Count int64
+	}
+
+	Pollers []struct {
+		Type  string
 		Count int64
 	}
 

--- a/internal/common/debug/workerstats_noop.go
+++ b/internal/common/debug/workerstats_noop.go
@@ -29,9 +29,9 @@ type (
 	activityTrackerNoopImpl struct{}
 )
 
-func (lc *pollerTrackerNoopImpl) Start() Stopper { return &stopperNoopImpl{} }
-func (lc *pollerTrackerNoopImpl) Stats() int32   { return 0 }
-func (r *stopperNoopImpl) Stop()                 {}
+func (lc *pollerTrackerNoopImpl) Start(workerType string) Stopper { return &stopperNoopImpl{} }
+func (lc *pollerTrackerNoopImpl) Stats() Pollers                  { return nil }
+func (r *stopperNoopImpl) Stop()                                  {}
 
 // NewNoopPollerTracker creates a new PollerTracker instance
 func NewNoopPollerTracker() PollerTracker { return &pollerTrackerNoopImpl{} }

--- a/internal/common/debug/workerstats_noop_test.go
+++ b/internal/common/debug/workerstats_noop_test.go
@@ -30,9 +30,9 @@ func TestWorkerStats(t *testing.T) {
 	pollerTracker := NewNoopPollerTracker()
 	activityTracker := NewNoopActivityTracker()
 	assert.NotNil(t, pollerTracker)
-	assert.NotNil(t, pollerTracker.Start())
-	assert.Equal(t, int32(0), pollerTracker.Stats())
-	assert.NotPanics(t, pollerTracker.Start().Stop)
+	assert.NotNil(t, pollerTracker.Start(""))
+	assert.Nil(t, pollerTracker.Stats())
+	assert.NotPanics(t, pollerTracker.Start("").Stop)
 	assert.NotNil(t, activityTracker.Start(ActivityInfo{}))
 	assert.Nil(t, activityTracker.Stats())
 }

--- a/internal/internal_worker_base.go
+++ b/internal/internal_worker_base.go
@@ -236,7 +236,7 @@ func (bw *baseWorker) isShutdown() bool {
 
 func (bw *baseWorker) runPoller() {
 	defer bw.shutdownWG.Done()
-	defer bw.options.pollerTracker.Start().Stop()
+	defer bw.options.pollerTracker.Start(bw.options.workerType).Stop()
 
 	bw.metricsScope.Counter(metrics.PollerStartCounter).Inc(1)
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
We use the PollerTracker interface to count the number of running pollers and we display it internal in a debug page.
This change is updating the interface and its usage so that the poller count is broken down by worker type (e.g: activity, workflow, shadow, localactivity, etc.)

<!-- Tell your future self why have you made these changes -->
**Why?**
The break down gives a better insight on the running instance

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
