### PR TITLE
Fix incorrect nil handling in workflowTaskPoller

### DIFF
--- a/internal/internal_task_pollers.go
+++ b/internal/internal_task_pollers.go
@@ -291,7 +291,7 @@ func newWorkflowTaskPoller(
 	params workerExecutionParameters,
 ) *workflowTaskPoller {
 	/*
-	Explicit nil handling is needed here. Otherwise, poller.ldaTunnel would not return a nil result
+		Explicit nil handling is needed here. Otherwise, poller.ldaTunnel would not return a nil result
 	*/
 	var ldaTunnelInterface localDispatcher
 	if ldaTunnel != nil {

--- a/internal/internal_task_pollers.go
+++ b/internal/internal_task_pollers.go
@@ -290,6 +290,14 @@ func newWorkflowTaskPoller(
 	domain string,
 	params workerExecutionParameters,
 ) *workflowTaskPoller {
+	/*
+	Explicit nil handling is needed here. Otherwise, poller.ldaTunnel would not return a nil result
+	*/
+	var ldaTunnelInterface localDispatcher
+	if ldaTunnel != nil {
+		ldaTunnelInterface = ldaTunnel
+	}
+
 	return &workflowTaskPoller{
 		basePoller:                   basePoller{shutdownC: params.WorkerStopChannel},
 		service:                      service,
@@ -297,7 +305,7 @@ func newWorkflowTaskPoller(
 		taskListName:                 params.TaskList,
 		identity:                     params.Identity,
 		taskHandler:                  taskHandler,
-		ldaTunnel:                    ldaTunnel,
+		ldaTunnel:                    ldaTunnelInterface,
 		metricsScope:                 metrics.NewTaggedScope(params.MetricsScope),
 		logger:                       params.Logger,
 		stickyUUID:                   uuid.New(),

--- a/internal/internal_task_pollers_test.go
+++ b/internal/internal_task_pollers_test.go
@@ -46,6 +46,21 @@ const (
 	_testIdentity   = "test-worker"
 )
 
+func Test_newWorkflowTaskPoller(t *testing.T) {
+	t.Run("success with nil ldaTunnel", func(t *testing.T) {
+		poller := newWorkflowTaskPoller(
+			nil,
+			nil,
+			nil,
+			_testDomainName,
+			workerExecutionParameters{})
+		assert.NotNil(t, poller)
+		if poller.ldaTunnel != nil {
+			t.Error("unexpected not nil ldaTunnel")
+		}
+	})
+}
+
 func TestLocalActivityPanic(t *testing.T) {
 	// regression: panics in local activities should not terminate the process
 	s := WorkflowTestSuite{logger: testlogger.NewZap(t)}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

* explicit nil handling in newWorkflowTaskPoller for ldaTunnel

<!-- Tell your future self why have you made these changes -->
**Why?**

Golang doesn't handle passing in nil pointer of concrete type directly into the interface. It still considers it not nil, which will cause panic in this case. 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

Unit test fail before and pass after the change

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
