### PR TITLE
Minor race prevention: do not mutate callers' retry policy

### DIFF
--- a/internal/workflow.go
+++ b/internal/workflow.go
@@ -1849,9 +1849,6 @@ func convertRetryPolicy(retryPolicy *RetryPolicy) *s.RetryPolicy {
 	if retryPolicy == nil {
 		return nil
 	}
-	if retryPolicy.BackoffCoefficient == 0 {
-		retryPolicy.BackoffCoefficient = backoff.DefaultBackoffCoefficient
-	}
 	thriftRetryPolicy := s.RetryPolicy{
 		InitialIntervalInSeconds:    common.Int32Ptr(common.Int32Ceil(retryPolicy.InitialInterval.Seconds())),
 		MaximumIntervalInSeconds:    common.Int32Ptr(common.Int32Ceil(retryPolicy.MaximumInterval.Seconds())),
@@ -1859,6 +1856,9 @@ func convertRetryPolicy(retryPolicy *RetryPolicy) *s.RetryPolicy {
 		MaximumAttempts:             &retryPolicy.MaximumAttempts,
 		NonRetriableErrorReasons:    retryPolicy.NonRetriableErrorReasons,
 		ExpirationIntervalInSeconds: common.Int32Ptr(common.Int32Ceil(retryPolicy.ExpirationInterval.Seconds())),
+	}
+	if *thriftRetryPolicy.BackoffCoefficient == 0 {
+		thriftRetryPolicy.BackoffCoefficient = common.Float64Ptr(backoff.DefaultBackoffCoefficient)
 	}
 	return &thriftRetryPolicy
 }


### PR DESCRIPTION
**Detailed Description**

Concurrently calling `workflow.WithActivityOptions` with a shared retry policy instance that does not set a backoff coefficient can trigger a race because this function mutated it unnecessarily.

The fix is easy: just don't do that :)

**Impact Analysis**
Fixes tests and prod that share activity-option-vars, which is somewhat common in some codebases.  I'm not sure if this can lead to any _actual_ misbehavior since it's a single-word value and it's only ever adjusted to one other value, but I'm fully on board with "never allow races no matter what".

**Testing Plan**
Test suite should be plenty.

**Rollout Plan**
Nothing special.