### PR TITLE
Add possibility to remove the RetryPolicy from the workflow context without overriding the other existing ActivityOptions in it

### DIFF
--- a/internal/workflow.go
+++ b/internal/workflow.go
@@ -1839,9 +1839,9 @@ func WithWaitForCancellation(ctx Context, wait bool) Context {
 }
 
 // WithRetryPolicy adds retry policy to the copy of the context
-func WithRetryPolicy(ctx Context, retryPolicy RetryPolicy) Context {
+func WithRetryPolicy(ctx Context, retryPolicy *RetryPolicy) Context {
 	ctx1 := setActivityParametersIfNotExist(ctx)
-	getActivityOptions(ctx1).RetryPolicy = convertRetryPolicy(&retryPolicy)
+	getActivityOptions(ctx1).RetryPolicy = convertRetryPolicy(retryPolicy)
 	return ctx1
 }
 

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -205,6 +205,13 @@ func (ts *IntegrationTestSuite) TestActivityRetryOptionsChange() {
 	ts.EqualValues(expected, ts.activities.invoked())
 }
 
+func (ts *IntegrationTestSuite) TestActivityRetryOptionsRemove() {
+	var expected []string
+	err := ts.executeWorkflow("test-activity-retry-options-remove", ts.workflows.ActivityRetryOptionsRemove, &expected)
+	ts.NoError(err)
+	ts.EqualValues(expected, ts.activities.invoked())
+}
+
 func (ts *IntegrationTestSuite) TestActivityRetryOnStartToCloseTimeout() {
 	var expected []string
 	err := ts.executeWorkflow(

--- a/test/workflow_test.go
+++ b/test/workflow_test.go
@@ -99,6 +99,17 @@ func (w *Workflows) ActivityRetryOptionsChange(ctx workflow.Context) ([]string, 
 	return []string{"fail", "fail"}, nil
 }
 
+func (w *Workflows) ActivityRetryOptionsRemove(ctx workflow.Context) ([]string, error) {
+	opts := w.defaultActivityOptionsWithRetry()
+	ctx = workflow.WithActivityOptions(ctx, opts)
+	ctx = workflow.WithRetryPolicy(ctx, nil)
+	err := workflow.ExecuteActivity(ctx, "Fail").Get(ctx, nil)
+	if err == nil {
+		return nil, fmt.Errorf("expected activity to fail but succeeded")
+	}
+	return []string{"fail"}, nil
+}
+
 func (w *Workflows) ActivityRetryOnTimeout(ctx workflow.Context, timeoutType shared.TimeoutType) ([]string, error) {
 	opts := w.defaultActivityOptionsWithRetry()
 	switch timeoutType {
@@ -625,6 +636,7 @@ func (w *Workflows) register(worker worker.Worker) {
 	worker.RegisterWorkflow(w.ActivityAutoHeartbeat)
 	worker.RegisterWorkflow(w.ActivityRetryOnTimeout)
 	worker.RegisterWorkflow(w.ActivityRetryOptionsChange)
+	worker.RegisterWorkflow(w.ActivityRetryOptionsRemove)
 	worker.RegisterWorkflow(w.ContinueAsNew)
 	worker.RegisterWorkflow(w.ContinueAsNewWithOptions)
 	worker.RegisterWorkflow(w.IDReusePolicy)

--- a/workflow/activity_options.go
+++ b/workflow/activity_options.go
@@ -118,6 +118,6 @@ func WithWaitForCancellation(ctx Context, wait bool) Context {
 // WithRetryPolicy makes a copy of the current context and update
 // the RetryPolicy field in its activity options. An empty activity
 // options will be created if it does not exist in the original context.
-func WithRetryPolicy(ctx Context, retryPolicy RetryPolicy) Context {
+func WithRetryPolicy(ctx Context, retryPolicy *RetryPolicy) Context {
 	return internal.WithRetryPolicy(ctx, retryPolicy)
 }


### PR DESCRIPTION

<!-- Describe what has changed in this PR -->
The WithRetryPolicy function accepts a pointer receiver RetryPolicy parameter, so it can be used to remove the RetryPolicy from the ActivityOptions.


<!-- Tell your future self why have you made these changes -->
I set the ActivityOptions including a non-nil RetryOptions configuration at the beginning of my workflow, these ActivityOptions are used by all activities in my workflow by default. I would like to override the RetryPolicy to nil for just one activity in that workflow without overriding the other ActivityOptions configurations.


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
I added a unit test.


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
When users set a retryPolicy with the WithRetryPolicy function, it could be broken, so the workflow might not be retried even if the RetryPolicy is set.
