### PR TITLE
Add workflow.GetSpanContext and workflow.WithSpanContext API

### DIFF
--- a/internal/context.go
+++ b/internal/context.go
@@ -494,6 +494,6 @@ func GetSpanContext(ctx Context) opentracing.SpanContext {
 	return nil
 }
 
-func contextWithSpan(ctx Context, spanContext opentracing.SpanContext) Context {
+func WithSpanContext(ctx Context, spanContext opentracing.SpanContext) Context {
 	return WithValue(ctx, activeSpanContextKey, spanContext)
 }

--- a/internal/context.go
+++ b/internal/context.go
@@ -486,7 +486,7 @@ func (c *valueCtx) Value(key interface{}) interface{} {
 	return c.Context.Value(key)
 }
 
-func spanFromContext(ctx Context) opentracing.SpanContext {
+func GetSpanContext(ctx Context) opentracing.SpanContext {
 	val := ctx.Value(activeSpanContextKey)
 	if sp, ok := val.(opentracing.SpanContext); ok {
 		return sp

--- a/internal/tracer.go
+++ b/internal/tracer.go
@@ -103,7 +103,7 @@ func (t *tracingContextPropagator) InjectFromWorkflow(
 	hw HeaderWriter,
 ) error {
 	// retrieve span from context object
-	spanContext := spanFromContext(ctx)
+	spanContext := GetSpanContext(ctx)
 	if spanContext == nil {
 		return nil
 	}

--- a/internal/tracer.go
+++ b/internal/tracer.go
@@ -119,5 +119,5 @@ func (t *tracingContextPropagator) ExtractToWorkflow(
 		// did not find a tracing span, just return the current context
 		return ctx, nil
 	}
-	return contextWithSpan(ctx, spanContext), nil
+	return WithSpanContext(ctx, spanContext), nil
 }

--- a/internal/tracer_test.go
+++ b/internal/tracer_test.go
@@ -82,7 +82,7 @@ func TestTracingContextPropagatorWorkflowContext(t *testing.T) {
 
 	span := tracer.StartSpan("test-operation")
 	assert.NotNil(t, span.Context())
-	ctx := contextWithSpan(Background(), span.Context())
+	ctx := WithSpanContext(Background(), span.Context())
 	header := &shared.Header{
 		Fields: map[string][]byte{},
 	}
@@ -130,7 +130,7 @@ func TestConsistentInjectionExtraction(t *testing.T) {
 	var baggageVal = "e30="
 	span.SetBaggageItem("request-tenancy", baggageVal)
 	assert.NotNil(t, span.Context())
-	ctx := contextWithSpan(Background(), span.Context())
+	ctx := WithSpanContext(Background(), span.Context())
 	header := &shared.Header{
 		Fields: map[string][]byte{},
 	}

--- a/internal/tracer_test.go
+++ b/internal/tracer_test.go
@@ -96,9 +96,9 @@ func TestTracingContextPropagatorWorkflowContext(t *testing.T) {
 	returnCtx2, err := ctxProp.ExtractToWorkflow(Background(), NewHeaderReader(header))
 	require.NoError(t, err)
 
-	newSpanContext := spanFromContext(returnCtx)
+	newSpanContext := GetSpanContext(returnCtx)
 	assert.NotNil(t, newSpanContext)
-	newSpanContext2 := spanFromContext(returnCtx2)
+	newSpanContext2 := GetSpanContext(returnCtx2)
 	assert.NotNil(t, newSpanContext2)
 	assert.Equal(t, newSpanContext2, newSpanContext)
 }
@@ -140,7 +140,7 @@ func TestConsistentInjectionExtraction(t *testing.T) {
 	extractedCtx, err := ctxProp.ExtractToWorkflow(Background(), NewHeaderReader(header))
 	require.NoError(t, err)
 
-	extractedSpanContext := spanFromContext(extractedCtx)
+	extractedSpanContext := GetSpanContext(extractedCtx)
 	extractedSpanContext.ForeachBaggageItem(func(k, v string) bool {
 		if k == "request-tenancy" {
 			assert.Equal(t, v, baggageVal)

--- a/workflow/context.go
+++ b/workflow/context.go
@@ -93,3 +93,26 @@ func NewDisconnectedContext(parent Context) (ctx Context, cancel CancelFunc) {
 func GetSpanContext(ctx Context) opentracing.SpanContext {
 	return internal.GetSpanContext(ctx)
 }
+
+// WithSpanContext returns [Context] with override [opentracing.SpanContext].
+// This is useful to modify baggage items of current workflow and pass it to activities and child workflows.
+//
+// Example Usage:
+//	func myWorkflow(ctx Context) error {
+// 		// start a new workflow span
+// 		wSpan := opentracing.StartSpan("workflow-operation", opentracing.ChildOf(spanContext))
+// 		// pass the new span context to activity
+// 		aCtx := WithSpanContext(ctx, wSpan.Context())
+// 		var activityFooResult string
+// 		err := ExecuteActivity(aCtx, ActivityFoo).Get(aCtx, &activityFooResult)
+// 		if err != nil {
+// 			wSpan.SetTag("workflow-error", err)
+// 		} else {
+// 			wSpan.SetTag("workflow-result", activityFooResult)
+// 		}
+// 		wSpan.Finish()
+// 		return activityFooResult, err
+// 	}
+func WithSpanContext(ctx Context, spanContext opentracing.SpanContext) Context {
+	return internal.WithSpanContext(ctx, spanContext)
+}

--- a/workflow/context.go
+++ b/workflow/context.go
@@ -21,9 +21,8 @@
 package workflow
 
 import (
-	"fmt"
-
 	"github.com/opentracing/opentracing-go"
+
 	"go.uber.org/cadence/internal"
 )
 
@@ -100,42 +99,44 @@ func GetSpanContext(ctx Context) opentracing.SpanContext {
 // This is useful to modify baggage items of current workflow and pass it to activities and child workflows.
 //
 // Example Usage:
-// func goodWorkflow(ctx Context) (string, error) {
-// 	// start a short lived new workflow span within SideEffect to avoid duplicate span creation during replay
-// 	spanContextValue := SideEffect(ctx, func(ctx Context) interface{} {
-// 		wSpan := opentracing.StartSpan("workflow-operation-with-new-span", opentracing.ChildOf(GetSpanContext(ctx)))
-// 		defer wSpan.Finish()
-// 		wSpan.SetTag("some-key", "some-value")
-// 		return wSpan.Context()
-// 	})
-// 	var spanContext opentracing.SpanContext
-// 	err := spanContextValue.Get(&spanContext)
-// 	if err != nil {
-// 		return "",fmt.Errorf("failed to get span context: %w", err)
-// 	}
 //
-// 	aCtx := WithSpanContext(ctx, spanContext)
-// 	var activityFooResult string
-// 	err = ExecuteActivity(aCtx, activityFoo).Get(aCtx, &activityFooResult)
-// 	return activityFooResult, err
-// }
+//	func goodWorkflow(ctx Context) (string, error) {
+//		// start a short lived new workflow span within SideEffect to avoid duplicate span creation during replay
+//		spanContextValue := SideEffect(ctx, func(ctx Context) interface{} {
+//			wSpan := opentracing.StartSpan("workflow-operation-with-new-span", opentracing.ChildOf(GetSpanContext(ctx)))
+//			defer wSpan.Finish()
+//			wSpan.SetTag("some-key", "some-value")
+//			return wSpan.Context()
+//		})
+//		var spanContext opentracing.SpanContext
+//		err := spanContextValue.Get(&spanContext)
+//		if err != nil {
+//			return "",fmt.Errorf("failed to get span context: %w", err)
+//		}
+//
+//		aCtx := WithSpanContext(ctx, spanContext)
+//		var activityFooResult string
+//		err = ExecuteActivity(aCtx, activityFoo).Get(aCtx, &activityFooResult)
+//		return activityFooResult, err
+//	}
 //
 // Bad Example:
-// func badWorkflow(ctx Context) (string, error) {
-// 	// start a new workflow span for EVERY REPLAY
-// 	wSpan := opentracing.StartSpan("workflow-operation", opentracing.ChildOf(GetSpanContext(ctx)))
-// 	wSpan.SetBaggageItem("some-key", "some-value")
-// 	// pass the new span context to activity
-// 	aCtx := WithSpanContext(ctx, wSpan.Context())
-// 	var activityFooResult string
-// 	err := ExecuteActivity(aCtx, activityFoo).Get(aCtx, &activityFooResult)
-// 	wSpan.Finish()
-// 	return activityFooResult, err
-// }
 //
-// func activityFoo(ctx Context) (string, error) {
-// 	return "activity-foo-result", nil
-// }
+//	func badWorkflow(ctx Context) (string, error) {
+//		// start a new workflow span for EVERY REPLAY
+//		wSpan := opentracing.StartSpan("workflow-operation", opentracing.ChildOf(GetSpanContext(ctx)))
+//		wSpan.SetBaggageItem("some-key", "some-value")
+//		// pass the new span context to activity
+//		aCtx := WithSpanContext(ctx, wSpan.Context())
+//		var activityFooResult string
+//		err := ExecuteActivity(aCtx, activityFoo).Get(aCtx, &activityFooResult)
+//		wSpan.Finish()
+//		return activityFooResult, err
+//	}
+//
+//	func activityFoo(ctx Context) (string, error) {
+//		return "activity-foo-result", nil
+//	}
 func WithSpanContext(ctx Context, spanContext opentracing.SpanContext) Context {
 	return internal.WithSpanContext(ctx, spanContext)
 }

--- a/workflow/context.go
+++ b/workflow/context.go
@@ -21,6 +21,8 @@
 package workflow
 
 import (
+	"fmt"
+
 	"github.com/opentracing/opentracing-go"
 	"go.uber.org/cadence/internal"
 )
@@ -98,21 +100,42 @@ func GetSpanContext(ctx Context) opentracing.SpanContext {
 // This is useful to modify baggage items of current workflow and pass it to activities and child workflows.
 //
 // Example Usage:
-//	func myWorkflow(ctx Context) error {
-// 		// start a new workflow span
-// 		wSpan := opentracing.StartSpan("workflow-operation", opentracing.ChildOf(spanContext))
-// 		// pass the new span context to activity
-// 		aCtx := WithSpanContext(ctx, wSpan.Context())
-// 		var activityFooResult string
-// 		err := ExecuteActivity(aCtx, ActivityFoo).Get(aCtx, &activityFooResult)
-// 		if err != nil {
-// 			wSpan.SetTag("workflow-error", err)
-// 		} else {
-// 			wSpan.SetTag("workflow-result", activityFooResult)
-// 		}
-// 		wSpan.Finish()
-// 		return activityFooResult, err
+// func goodWorkflow(ctx Context) (string, error) {
+// 	// start a short lived new workflow span within SideEffect to avoid duplicate span creation during replay
+// 	spanContextValue := SideEffect(ctx, func(ctx Context) interface{} {
+// 		wSpan := opentracing.StartSpan("workflow-operation-with-new-span", opentracing.ChildOf(GetSpanContext(ctx)))
+// 		defer wSpan.Finish()
+// 		wSpan.SetTag("some-key", "some-value")
+// 		return wSpan.Context()
+// 	})
+// 	var spanContext opentracing.SpanContext
+// 	err := spanContextValue.Get(&spanContext)
+// 	if err != nil {
+// 		return "",fmt.Errorf("failed to get span context: %w", err)
 // 	}
+//
+// 	aCtx := WithSpanContext(ctx, spanContext)
+// 	var activityFooResult string
+// 	err = ExecuteActivity(aCtx, activityFoo).Get(aCtx, &activityFooResult)
+// 	return activityFooResult, err
+// }
+//
+// Bad Example:
+// func badWorkflow(ctx Context) (string, error) {
+// 	// start a new workflow span for EVERY REPLAY
+// 	wSpan := opentracing.StartSpan("workflow-operation", opentracing.ChildOf(GetSpanContext(ctx)))
+// 	wSpan.SetBaggageItem("some-key", "some-value")
+// 	// pass the new span context to activity
+// 	aCtx := WithSpanContext(ctx, wSpan.Context())
+// 	var activityFooResult string
+// 	err := ExecuteActivity(aCtx, activityFoo).Get(aCtx, &activityFooResult)
+// 	wSpan.Finish()
+// 	return activityFooResult, err
+// }
+//
+// func activityFoo(ctx Context) (string, error) {
+// 	return "activity-foo-result", nil
+// }
 func WithSpanContext(ctx Context, spanContext opentracing.SpanContext) Context {
 	return internal.WithSpanContext(ctx, spanContext)
 }

--- a/workflow/context.go
+++ b/workflow/context.go
@@ -21,6 +21,7 @@
 package workflow
 
 import (
+	"github.com/opentracing/opentracing-go"
 	"go.uber.org/cadence/internal"
 )
 
@@ -75,4 +76,20 @@ func WithValue(parent Context, key interface{}, val interface{}) Context {
 //	}
 func NewDisconnectedContext(parent Context) (ctx Context, cancel CancelFunc) {
 	return internal.NewDisconnectedContext(parent)
+}
+
+// GetSpanContext returns the [opentracing.SpanContext] from [Context].
+// Returns nil if tracer is not set in [go.uber.org/cadence/worker.Options].
+//
+// Note: If tracer is set, we already activate a span for each workflow.
+// This SpanContext will be passed to the activities and child workflows to start new spans.
+//
+// Example Usage:
+//
+//	span := GetSpanContext(ctx)
+//	if span != nil {
+//		span.SetTag("foo", "bar")
+//	}
+func GetSpanContext(ctx Context) opentracing.SpanContext {
+	return internal.GetSpanContext(ctx)
 }


### PR DESCRIPTION
**Detailed Description**

* GetSpanContext API is used for fetch span context from workflow if it exists
* WithSpanContext() API is used for overriding the existing span context in the workflow so it could be passed to activities and child workflows

**Impact Analysis**
- **Backward Compatibility**: Yes, they are new APIs
- **Forward Compatibility**: Yes, WithSpanContext would write the existing span context field and it's readable for old client versions

**Testing Plan**
- **Unit Tests**: No
- **Persistence Tests**: No
- **Integration Tests**: Yes
- **Compatibility Tests**: No

**Rollout Plan**
- What is the rollout plan? new release
- Does the order of deployment matter? no
- Is it safe to rollback? Does the order of rollback matter? Safe
- Is there a kill switch to mitigate the impact immediately? Rollback to previous version and remove usages of the new APIs

<!-- Tell your future self why have you made these changes -->
**Why?**

Users can now access baggage items in the workflow code. 
