### PR TITLE
fix correct initial poller count for autoscaler

### DIFF
--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -276,21 +276,17 @@ func newWorkflowTaskWorkerInternal(
 		domain,
 		params,
 	)
-	pollerCount := params.MaxConcurrentDecisionTaskPollers
-	if params.AutoScalerOptions.Enabled {
-		pollerCount = params.AutoScalerOptions.PollerInitCount
-	}
 	worker := newBaseWorker(baseWorkerOptions{
-		pollerAutoScaler:  params.AutoScalerOptions,
-		pollerCount:       pollerCount,
-		pollerRate:        defaultPollerRate,
-		maxConcurrentTask: params.MaxConcurrentDecisionTaskExecutionSize,
-		maxTaskPerSecond:  params.WorkerDecisionTasksPerSecond,
-		taskWorker:        poller,
-		identity:          params.Identity,
-		workerType:        "DecisionWorker",
-		shutdownTimeout:   params.WorkerStopTimeout,
-		pollerTracker:     params.WorkerStats.PollerTracker,
+		pollerAutoScaler:              params.AutoScalerOptions,
+		pollerCountWithoutAutoScaling: params.MaxConcurrentDecisionTaskPollers,
+		pollerRate:                    defaultPollerRate,
+		maxConcurrentTask:             params.MaxConcurrentDecisionTaskExecutionSize,
+		maxTaskPerSecond:              params.WorkerDecisionTasksPerSecond,
+		taskWorker:                    poller,
+		identity:                      params.Identity,
+		workerType:                    "DecisionWorker",
+		shutdownTimeout:               params.WorkerStopTimeout,
+		pollerTracker:                 params.WorkerStats.PollerTracker,
 	},
 		params.Logger,
 		params.MetricsScope,
@@ -308,14 +304,14 @@ func newWorkflowTaskWorkerInternal(
 	// 2) local activity task poller will poll from laTunnel, and result will be pushed to laTunnel
 	localActivityTaskPoller := newLocalActivityPoller(params, laTunnel)
 	localActivityWorker := newBaseWorker(baseWorkerOptions{
-		pollerCount:       1, // 1 poller (from local channel) is enough for local activity
-		maxConcurrentTask: params.MaxConcurrentLocalActivityExecutionSize,
-		maxTaskPerSecond:  params.WorkerLocalActivitiesPerSecond,
-		taskWorker:        localActivityTaskPoller,
-		identity:          params.Identity,
-		workerType:        "LocalActivityWorker",
-		shutdownTimeout:   params.WorkerStopTimeout,
-		pollerTracker:     params.WorkerStats.PollerTracker,
+		pollerCountWithoutAutoScaling: 1, // 1 poller (from local channel) is enough for local activity
+		maxConcurrentTask:             params.MaxConcurrentLocalActivityExecutionSize,
+		maxTaskPerSecond:              params.WorkerLocalActivitiesPerSecond,
+		taskWorker:                    localActivityTaskPoller,
+		identity:                      params.Identity,
+		workerType:                    "LocalActivityWorker",
+		shutdownTimeout:               params.WorkerStopTimeout,
+		pollerTracker:                 params.WorkerStats.PollerTracker,
 	},
 		params.Logger,
 		params.MetricsScope,
@@ -472,23 +468,19 @@ func newActivityTaskWorker(
 	workerType string,
 ) (worker *activityWorker) {
 	ensureRequiredParams(&workerParams)
-	pollerCount := workerParams.MaxConcurrentActivityTaskPollers
-	if workerParams.AutoScalerOptions.Enabled {
-		pollerCount = workerParams.AutoScalerOptions.PollerInitCount
-	}
 	base := newBaseWorker(
 		baseWorkerOptions{
-			pollerAutoScaler:  workerParams.AutoScalerOptions,
-			pollerCount:       pollerCount,
-			pollerRate:        defaultPollerRate,
-			maxConcurrentTask: workerParams.MaxConcurrentActivityExecutionSize,
-			maxTaskPerSecond:  workerParams.WorkerActivitiesPerSecond,
-			taskWorker:        poller,
-			identity:          workerParams.Identity,
-			workerType:        workerType,
-			shutdownTimeout:   workerParams.WorkerStopTimeout,
-			userContextCancel: workerParams.UserContextCancel,
-			pollerTracker:     workerParams.WorkerStats.PollerTracker,
+			pollerAutoScaler:              workerParams.AutoScalerOptions,
+			pollerCountWithoutAutoScaling: workerParams.MaxConcurrentActivityTaskPollers,
+			pollerRate:                    defaultPollerRate,
+			maxConcurrentTask:             workerParams.MaxConcurrentActivityExecutionSize,
+			maxTaskPerSecond:              workerParams.WorkerActivitiesPerSecond,
+			taskWorker:                    poller,
+			identity:                      workerParams.Identity,
+			workerType:                    workerType,
+			shutdownTimeout:               workerParams.WorkerStopTimeout,
+			userContextCancel:             workerParams.UserContextCancel,
+			pollerTracker:                 workerParams.WorkerStats.PollerTracker,
 		},
 
 		workerParams.Logger,


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

* rename pollerCount to less confusing name `pollerCountWithoutAutoscaling`
* ensure starting enough goroutines for pollers when autoscaler is enabled

<!-- Tell your future self why have you made these changes -->
**Why?**

Consider a case when autoscaler is enabled with 40 max, 10 initial, 2 min. We need to start 40 poller goroutines first and only allow 10 to pass initially. 

This is achieved by starting 40 `go bw.runPoller()` goroutines and set `PollerPermit` to 10. 

The bug we have now is we only start 10 goroutines at the beginning so it just won't scale up. 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

bench test with stable tasklist traffic. 

Pollers are 2 intially with 20 instances with autoscaler enabled. 
After scaling down 20 -> 10 and 10 -> 2. We saw the poller quota increased to cover the loss of hosts. Schedule to start latency is maintained. 

<img width="1272" height="1341" alt="Screenshot 2025-07-17 at 4 04 02 PM" src="https://github.com/user-attachments/assets/c860960d-c4d2-4972-b802-9b936c8d093b" />


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

Additional goroutines will be created but it's ok because we are already creating a max of 10k goroutines by default for sticky executions. 
