### PR TITLE
Fix zero value in task permit histogram metrics

### DIFF
--- a/internal/internal_worker_base.go
+++ b/internal/internal_worker_base.go
@@ -53,7 +53,7 @@ const (
 
 var (
 	pollOperationRetryPolicy       = createPollRetryPolicy()
-	concurrentTaskHistogramBuckets = tally.ValueBuckets{10, 20, 50, 100, 150, 200, 400, 600, 800, 1000, 1500, 2000, 3000, 5000, 10000}
+	concurrentTaskHistogramBuckets = tally.ValueBuckets{0, 10, 20, 50, 100, 150, 200, 400, 600, 800, 1000, 1500, 2000, 3000, 5000, 10000}
 )
 
 var errShutdown = errors.New("worker shutting down")


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

* add zero value in the histogram buckets

<!-- Tell your future self why have you made these changes -->
**Why?**

Users are confused on the zero value being 10 instead of 0 when they are looking at the passive side usage. 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
