### PR TITLE
Add HasActivityInfo to avoid panic recover on GetActivityInfo

### DIFF
--- a/internal/activity.go
+++ b/internal/activity.go
@@ -224,6 +224,12 @@ func GetActivityInfo(ctx context.Context) ActivityInfo {
 	}
 }
 
+// HasActivityInfo returns if the context contains activity information
+// Should be used before GetActivityInfo to avoid panic
+func HasActivityInfo(ctx context.Context) bool {
+	return hasActivityEnv(ctx)
+}
+
 // HasHeartbeatDetails checks if there is heartbeat details from last attempt.
 func HasHeartbeatDetails(ctx context.Context) bool {
 	env := getActivityEnv(ctx)

--- a/internal/activity_test.go
+++ b/internal/activity_test.go
@@ -233,3 +233,25 @@ func (s *activityTestSuite) TestGetWorkerStopChannel() {
 	channel := GetWorkerStopChannel(ctx)
 	s.NotNil(channel)
 }
+
+func (s *activityTestSuite) TestHasActivityInfo() {
+	// Test context without activity info
+	ctx := context.Background()
+	s.False(HasActivityInfo(ctx))
+
+	// Test context with activity info
+	activityEnv := &activityEnvironment{
+		activityID:   "test-activity-id",
+		activityType: ActivityType{Name: "test-activity-type"},
+	}
+	ctxWithActivity := context.WithValue(ctx, activityEnvContextKey, activityEnv)
+	s.True(HasActivityInfo(ctxWithActivity))
+
+	// Test context with nil activity env
+	ctxWithNilActivity := context.WithValue(ctx, activityEnvContextKey, nil)
+	s.False(HasActivityInfo(ctxWithNilActivity))
+
+	// Test context with other values in context
+	ctxWithOtherValue := context.WithValue(ctx, "other-key", "other-value")
+	s.False(HasActivityInfo(ctxWithOtherValue))
+}

--- a/internal/internal_activity.go
+++ b/internal/internal_activity.go
@@ -155,6 +155,11 @@ func getActivityEnv(ctx context.Context) *activityEnvironment {
 	return env.(*activityEnvironment)
 }
 
+func hasActivityEnv(ctx context.Context) bool {
+	env := ctx.Value(activityEnvContextKey)
+	return env != nil
+}
+
 func getActivityOptions(ctx Context) *activityOptions {
 	eap := ctx.Value(activityOptionsContextKey)
 	if eap == nil {


### PR DESCRIPTION
**What changed?**
Added a new method `HasActivityInfo` to `activity.go`

**Why?**
At my work, we use `GetActivityInfo` a lot to create some metrics in one core component. This component is heavily used in the system and called not only from cadence activities but also other places. The current implementation of `GetActivityInfo` panicking if called not from the activity, it forces us to use panic-recover pattern which works but pollute logs a lot:

```
defer func() {
    if r := recover(); r != nil {
        // Recovered from panic, context is not an activity context
        ok = false
    }
}()
info = activity.GetInfo(ctx)
```

We would like to avoid it with this:

```
if activity.HasActivityInfo(ctx) {
    info = activity.GetInfo(ctx)
}
```

**How did you test it?**
Unit tests

**Potential risks**
No risks, 100% safe change 
