### PR TITLE
Add attempt number to activity logger

### DIFF
--- a/internal/activity.go
+++ b/internal/activity.go
@@ -356,10 +356,8 @@ func WithActivityTask(
 		zapcore.Field{Key: tagWorkflowType, Type: zapcore.StringType, String: *task.WorkflowType.Name},
 		zapcore.Field{Key: tagWorkflowID, Type: zapcore.StringType, String: *task.WorkflowExecution.WorkflowId},
 		zapcore.Field{Key: tagRunID, Type: zapcore.StringType, String: *task.WorkflowExecution.RunId},
+		zapcore.Field{Key: tagAttempt, Type: zapcore.Int64Type, Integer: int64(*task.Attempt)},
 	)
-	if task.Attempt != nil {
-		logger = logger.With(zapcore.Field{Key: tagAttempt, Type: zapcore.Int64Type, Integer: int64(*task.Attempt)})
-	}
 
 	return context.WithValue(ctx, activityEnvContextKey, &activityEnvironment{
 		taskToken:      task.TaskToken,

--- a/internal/activity.go
+++ b/internal/activity.go
@@ -356,7 +356,7 @@ func WithActivityTask(
 		zapcore.Field{Key: tagWorkflowType, Type: zapcore.StringType, String: *task.WorkflowType.Name},
 		zapcore.Field{Key: tagWorkflowID, Type: zapcore.StringType, String: *task.WorkflowExecution.WorkflowId},
 		zapcore.Field{Key: tagRunID, Type: zapcore.StringType, String: *task.WorkflowExecution.RunId},
-		zapcore.Field{Key: tagAttempt, Type: zapcore.Int64Type, Integer: int64(*task.Attempt)},
+		zapcore.Field{Key: tagAttempt, Type: zapcore.Int64Type, Integer: int64(task.GetAttempt())},
 	)
 
 	return context.WithValue(ctx, activityEnvContextKey, &activityEnvironment{

--- a/internal/activity.go
+++ b/internal/activity.go
@@ -356,6 +356,7 @@ func WithActivityTask(
 		zapcore.Field{Key: tagWorkflowType, Type: zapcore.StringType, String: *task.WorkflowType.Name},
 		zapcore.Field{Key: tagWorkflowID, Type: zapcore.StringType, String: *task.WorkflowExecution.WorkflowId},
 		zapcore.Field{Key: tagRunID, Type: zapcore.StringType, String: *task.WorkflowExecution.RunId},
+		zapcore.Field{Key: tagAttempt, Type: zapcore.Int32Type, Int32: *task.Attempt},
 	)
 
 	return context.WithValue(ctx, activityEnvContextKey, &activityEnvironment{

--- a/internal/activity.go
+++ b/internal/activity.go
@@ -356,8 +356,10 @@ func WithActivityTask(
 		zapcore.Field{Key: tagWorkflowType, Type: zapcore.StringType, String: *task.WorkflowType.Name},
 		zapcore.Field{Key: tagWorkflowID, Type: zapcore.StringType, String: *task.WorkflowExecution.WorkflowId},
 		zapcore.Field{Key: tagRunID, Type: zapcore.StringType, String: *task.WorkflowExecution.RunId},
-		zapcore.Field{Key: tagAttempt, Type: zapcore.Int32Type, Int32: *task.Attempt},
 	)
+	if task.Attempt != nil {
+		logger = logger.With(zapcore.Field{Key: tagAttempt, Type: zapcore.Int64Type, Integer: int64(*task.Attempt)})
+	}
 
 	return context.WithValue(ctx, activityEnvContextKey, &activityEnvironment{
 		taskToken:      task.TaskToken,

--- a/internal/activity_task_handler_test.go
+++ b/internal/activity_task_handler_test.go
@@ -87,6 +87,7 @@ func TestActivityTaskHandler_Execute_deadline(t *testing.T) {
 				ScheduleToCloseTimeoutSeconds:   common.Int32Ptr(d.ScheduleDuration),
 				StartedTimestamp:                common.Int64Ptr(d.StartTS.UnixNano()),
 				StartToCloseTimeoutSeconds:      common.Int32Ptr(d.StartDuration),
+				Attempt:                         common.Int32Ptr(0),
 				WorkflowType: &s.WorkflowType{
 					Name: common.StringPtr("wType"),
 				},
@@ -139,6 +140,7 @@ func TestActivityTaskHandler_Execute_worker_stop(t *testing.T) {
 		ScheduleToCloseTimeoutSeconds:   common.Int32Ptr(1),
 		StartedTimestamp:                common.Int64Ptr(now.UnixNano()),
 		StartToCloseTimeoutSeconds:      common.Int32Ptr(1),
+		Attempt:                         common.Int32Ptr(0),
 		WorkflowType: &s.WorkflowType{
 			Name: common.StringPtr("wType"),
 		},
@@ -193,6 +195,7 @@ func TestActivityTaskHandler_Execute_with_propagators(t *testing.T) {
 		ScheduleToCloseTimeoutSeconds:   common.Int32Ptr(1),
 		StartedTimestamp:                common.Int64Ptr(now.UnixNano()),
 		StartToCloseTimeoutSeconds:      common.Int32Ptr(1),
+		Attempt:                         common.Int32Ptr(0),
 		WorkflowType: &s.WorkflowType{
 			Name: common.StringPtr("wType"),
 		},
@@ -245,6 +248,7 @@ func TestActivityTaskHandler_Execute_with_propagator_failure(t *testing.T) {
 		ScheduleToCloseTimeoutSeconds:   common.Int32Ptr(1),
 		StartedTimestamp:                common.Int64Ptr(now.UnixNano()),
 		StartToCloseTimeoutSeconds:      common.Int32Ptr(1),
+		Attempt:                         common.Int32Ptr(0),
 		WorkflowType: &s.WorkflowType{
 			Name: common.StringPtr("wType"),
 		},
@@ -301,6 +305,7 @@ func TestActivityTaskHandler_Execute_with_auto_heartbeat(t *testing.T) {
 		StartedTimestamp:                common.Int64Ptr(now.UnixNano()),
 		StartToCloseTimeoutSeconds:      common.Int32Ptr(1),
 		HeartbeatTimeoutSeconds:         common.Int32Ptr(1),
+		Attempt:                         common.Int32Ptr(0),
 		WorkflowType: &s.WorkflowType{
 			Name: common.StringPtr("wType"),
 		},

--- a/internal/internal_logging_tags.go
+++ b/internal/internal_logging_tags.go
@@ -26,6 +26,7 @@ const (
 	tagDomain                      = "Domain"
 	tagEventID                     = "EventID"
 	tagEventType                   = "EventType"
+	tagAttempt                     = "Attempt"
 	tagRunID                       = "RunID"
 	tagTaskList                    = "TaskList"
 	tagTimerID                     = "TimerID"

--- a/internal/internal_task_pollers.go
+++ b/internal/internal_task_pollers.go
@@ -611,7 +611,9 @@ func (lath *localActivityTaskHandler) executeLocalActivityTask(task *localActivi
 		zap.String(tagLocalActivityType, activityType),
 		zap.String(tagWorkflowType, workflowType),
 		zap.String(tagWorkflowID, task.params.WorkflowInfo.WorkflowExecution.ID),
-		zap.String(tagRunID, task.params.WorkflowInfo.WorkflowExecution.RunID))
+		zap.String(tagRunID, task.params.WorkflowInfo.WorkflowExecution.RunID),
+		zap.Int64(tagAttempt, int64(task.attempt)),
+	)
 
 	metricsScope.Counter(metrics.LocalActivityTotalCounter).Inc(1)
 

--- a/internal/internal_workers_test.go
+++ b/internal/internal_workers_test.go
@@ -156,6 +156,7 @@ func (s *WorkersTestSuite) TestActivityWorkerStop() {
 		ScheduleToCloseTimeoutSeconds:   common.Int32Ptr(1),
 		StartedTimestamp:                common.Int64Ptr(time.Now().UnixNano()),
 		StartToCloseTimeoutSeconds:      common.Int32Ptr(1),
+		Attempt:                         common.Int32Ptr(0),
 		WorkflowType: &m.WorkflowType{
 			Name: common.StringPtr("wType"),
 		},

--- a/internal/internal_workflow_testsuite.go
+++ b/internal/internal_workflow_testsuite.go
@@ -1699,6 +1699,7 @@ func newTestActivityTask(workflowID, runID, activityID, workflowTypeName, domain
 		StartedTimestamp:                common.Int64Ptr(time.Now().UnixNano()),
 		StartToCloseTimeoutSeconds:      common.Int32Ptr(params.StartToCloseTimeoutSeconds),
 		HeartbeatTimeoutSeconds:         common.Int32Ptr(params.HeartbeatTimeoutSeconds),
+		Attempt:                         common.Int32Ptr(0),
 		WorkflowType: &shared.WorkflowType{
 			Name: common.StringPtr(workflowTypeName),
 		},


### PR DESCRIPTION
**Detailed Description**
Adds attempt number to structured logs within `WithActivityTask` in activity.go and `executeLocalActivityTask` in internal_task_pollers.go.

**Impact Analysis**
- **Backward Compatibility**: No changes to core Cadence functionality or public API's / data structures.
- **Forward Compatibility**: Uses existing fields and doesn't introduce any new dependencies.

**Testing Plan**
- **Unit Tests**: Existing unit tests continue to pass.
- **Persistence Tests**: No changes to persisted data structures.
- **Integration Tests**: Existing tests continue to pass (activity execution behaviors are unchanged)
- **Compatibility Tests**: Existing tests continue to pass (activity execution behaviors are unchanged)

**Rollout Plan**
- What is the rollout plan?
    - Standard rollout / deployment process
- Does the order of deployment matter?
    - No specific order required.
- Is it safe to rollback? Does the order of rollback matter?
    - Completely safe to rollback, no specific order required either.
- Is there a kill switch to mitigate the impact immediately?
    - Not needed as no business logic changes. Can simply rollback the commit.