### PR TITLE
remove unnecessary debug level logging for autoscaler event

### DIFF
--- a/internal/internal_worker_test.go
+++ b/internal/internal_worker_test.go
@@ -1419,19 +1419,6 @@ func Test_augmentWorkerOptions(t *testing.T) {
 				},
 			},
 		},
-		{
-			name: "autoscaler options: some fields set",
-			args: args{options: WorkerOptions{
-				AutoScalerOptions: AutoScalerOptions{
-					Enabled: true,
-				},
-			}},
-			want: WorkerOptions{
-				AutoScalerOptions: AutoScalerOptions{
-					Enabled: true,
-				},
-			},
-		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/internal_worker_test.go
+++ b/internal/internal_worker_test.go
@@ -1419,6 +1419,19 @@ func Test_augmentWorkerOptions(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "autoscaler options: some fields set",
+			args: args{options: WorkerOptions{
+				AutoScalerOptions: AutoScalerOptions{
+					Enabled: true,
+				},
+			}},
+			want: WorkerOptions{
+				AutoScalerOptions: AutoScalerOptions{
+					Enabled: true,
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/worker/concurrency_auto_scaler.go
+++ b/internal/worker/concurrency_auto_scaler.go
@@ -216,11 +216,13 @@ func (c *ConcurrencyAutoScaler) logEvent(event autoScalerEvent) {
 	}
 	c.scope.Histogram(metricsPollerQuota, metricsPollerQuotaBuckets).RecordValue(float64(c.concurrency.PollerPermit.Quota()))
 	c.scope.Histogram(metricsPollerWaitTime, metricsPollerWaitTimeBuckets).RecordDuration(c.pollerWaitTime.Average())
-	c.log.Debug(autoScalerEventLogMsg,
-		zap.String("event", string(event)),
-		zap.Bool("enabled", c.enabled),
-		zap.Int("poller_quota", c.concurrency.PollerPermit.Quota()),
-	)
+	if event != autoScalerEventEmitMetrics {
+		c.log.Debug(autoScalerEventLogMsg,
+			zap.String("event", string(event)),
+			zap.Bool("enabled", c.enabled),
+			zap.Int("poller_quota", c.concurrency.PollerPermit.Quota()),
+		)
+	}
 }
 
 func (c *ConcurrencyAutoScaler) updatePollerPermit() {

--- a/internal/worker/concurrency_auto_scaler_test.go
+++ b/internal/worker/concurrency_auto_scaler_test.go
@@ -301,15 +301,13 @@ func TestConcurrencyAutoScaler(t *testing.T) {
 
 			var actualEvents []eventLog
 			for _, event := range obs.FilterMessage(autoScalerEventLogMsg).All() {
-				if event.ContextMap()["event"] != string(autoScalerEventEmitMetrics) {
-					t.Log("event: ", event.ContextMap())
+				t.Log("event: ", event.ContextMap())
 
-					actualEvents = append(actualEvents, eventLog{
-						eventType:   autoScalerEvent(event.ContextMap()["event"].(string)),
-						enabled:     event.ContextMap()["enabled"].(bool),
-						pollerQuota: event.ContextMap()["poller_quota"].(int64),
-					})
-				}
+				actualEvents = append(actualEvents, eventLog{
+					eventType:   autoScalerEvent(event.ContextMap()["event"].(string)),
+					enabled:     event.ContextMap()["enabled"].(bool),
+					pollerQuota: event.ContextMap()["poller_quota"].(int64),
+				})
 			}
 			assert.ElementsMatch(t, tt.expectedEvents, actualEvents)
 		})


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

Emit metrics logging happens every "cooldown time" (10s by default) and thus created a ton of debug logging. These logging are not needed.  

<!-- Tell your future self why have you made these changes -->
**Why?**

Some user complains about too much debug level logging

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

unit test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
