### PR TITLE
Autoscaler empty poll fix

### DIFF
--- a/internal/internal_task_pollers.go
+++ b/internal/internal_task_pollers.go
@@ -909,6 +909,7 @@ func (wtp *workflowTaskPoller) toWorkflowTask(response *s.PollForDecisionTaskRes
 	task := &workflowTask{
 		task:            response,
 		historyIterator: historyIterator,
+		autoConfigHint:  response.GetAutoConfigHint(),
 	}
 	return task
 }

--- a/internal/internal_task_pollers.go
+++ b/internal/internal_task_pollers.go
@@ -1096,7 +1096,7 @@ func (atp *activityTaskPoller) poll(ctx context.Context) (*s.PollForActivityTask
 	}
 	if response == nil || len(response.TaskToken) == 0 {
 		atp.metricsScope.Counter(metrics.ActivityPollNoTaskCounter).Inc(1)
-		return nil, startTime, nil
+		return response, startTime, nil
 	}
 
 	return response, startTime, err

--- a/internal/internal_task_pollers.go
+++ b/internal/internal_task_pollers.go
@@ -1130,7 +1130,7 @@ func (atp *activityTaskPoller) pollWithMetrics(ctx context.Context,
 	scheduledToStartLatency := time.Duration(response.GetStartedTimestamp() - response.GetScheduledTimestampOfThisAttempt())
 	metricsScope.Timer(metrics.ActivityScheduledToStartLatency).Record(scheduledToStartLatency)
 
-	return &activityTask{task: response, pollStartTime: startTime}, nil
+	return &activityTask{task: response, pollStartTime: startTime, autoConfigHint: response.GetAutoConfigHint()}, nil
 }
 
 // PollTask polls a new task


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

* activityWorker poll should populate autoConfigHint
* workflowWorker poll additional field population. This is optional but is good to have it

<!-- Tell your future self why have you made these changes -->
**Why?**

Activity worker doesn't process auto config hint on empty polls 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

Unit Test

Local Test with Cadence-Samples. Now it's scaling down correctly on empty poll scenarios
<img width="1498" height="638" alt="Screenshot 2025-08-27 at 1 56 18 PM" src="https://github.com/user-attachments/assets/71a8cefe-6103-4dda-aa50-e57c6fb97970" />

Also there is no panic/error logs in local testing

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
