### PR TITLE
Add missing request IDs

### DIFF
--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -34,6 +34,7 @@ import (
 	"time"
 
 	"github.com/opentracing/opentracing-go"
+	"github.com/pborman/uuid"
 	"github.com/uber-go/tally"
 	"go.uber.org/zap"
 
@@ -1627,6 +1628,7 @@ func signalWorkflow(
 		SignalName: common.StringPtr(signalName),
 		Input:      signalInput,
 		Identity:   common.StringPtr(identity),
+		RequestId:  common.StringPtr(uuid.New()),
 	}
 
 	return backoff.Retry(ctx,

--- a/internal/internal_workflow_client.go
+++ b/internal/internal_workflow_client.go
@@ -401,7 +401,8 @@ func (wc *workflowClient) CancelWorkflow(ctx context.Context, workflowID string,
 			WorkflowId: common.StringPtr(workflowID),
 			RunId:      getRunID(runID),
 		},
-		Identity: common.StringPtr(wc.identity),
+		Identity:  common.StringPtr(wc.identity),
+		RequestId: common.StringPtr(uuid.New()),
 	}
 
 	for _, opt := range opts {


### PR DESCRIPTION
These ensure idempotency across retries, which is particularly important for avoiding duplicate signals.

<!-- Describe what has changed in this PR -->
**What changed?**
- Add request IDs to requests missing them

<!-- Tell your future self why have you made these changes -->
**Why?**
- Prevent duplicate signals from retries

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
