### PR TITLE
ci: Lint PR titles with Conventional Commmit standard

### DIFF
--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -1,0 +1,72 @@
+name: Semantic Pull Request
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+jobs:
+  semantic-pr:
+    name: Validate PR title follows conventional commit format
+    runs-on: ubuntu-latest
+    # TODO: Remove this once we commit to conventional commits
+    continue-on-error: true
+
+    steps:
+      - name: Validate PR title
+        id: lint_pr_title
+        uses: amannn/action-semantic-pull-request@v5.4.0
+        with:
+          # Allow standard conventional commit types
+          types: |
+            fix
+            feat
+            docs
+            style
+            refactor
+            perf
+            test
+            chore
+            ci
+            build
+          # TODO: Remove this once we've decided on scopes
+          requireScope: false
+          # Skip validation for certain labels if needed
+          ignoreLabels: |
+            skip-commit-format
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Comment on PR if validation fails
+        if: steps.lint_pr_title.outputs.error_message != null
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `⚠️ **Semantic PR Check Failed**
+
+              **Error Details:**
+              \`\`\`
+              ${{ steps.lint_pr_title.outputs.error_message }}
+              \`\`\`
+
+              **Required Format:**
+              \`\`\`
+              <type>: <description>
+              \`\`\`
+
+              **Allowed types:** fix, feat, docs, style, refactor, perf, test, chore, ci, build
+
+              **Examples:**
+              - \`feat: add user authentication system\`
+              - \`fix: resolve memory leak in worker pool\`
+              - \`docs: update API documentation\`
+              - \`test: add integration tests for auth flow\`
+
+              This is currently a **warning only** and won't block your PR from being merged.`
+            })


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

Adds a linter to ensure the conventional commit standard is used for PR titles. 

<!-- Tell your future self why have you made these changes -->
**Why?**

See https://github.com/cadence-workflow/cadence/commit/c4b6330f9eb92461f5729be3e534dd5c16ed247d for more details. 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

In the cadence repo. 

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

N/A