### PR TITLE
ci: Allow gpg signed commits to pass DCO checks

### DIFF
--- a/.github/dco.yml
+++ b/.github/dco.yml
@@ -1,0 +1,2 @@
+require:
+  members: false


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

Allow gpg signed commits to pass DCO checks

<!-- Tell your future self why have you made these changes -->
**Why?**

DCO has been introduced to verify that each commit in the repository has been signed-off by the developer who is committing it. There are two ways to do this:
- `git commit -s -m "my message"
- sign each commit with a gpg key

This PR allows both of these methods to pass the check, rather than just the first. 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

[In the cadence repo. ](https://github.com/cadence-workflow/cadence)

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

N/A
