### PR TITLE
Fail unregistered activities immediately, not at schedule-to-close

### DIFF
--- a/internal/activity_task_handler.go
+++ b/internal/activity_task_handler.go
@@ -144,9 +144,13 @@ func (ath *activityTaskHandlerImpl) Execute(taskList string, t *s.PollForActivit
 
 	activityImplementation := ath.getActivity(activityType)
 	if activityImplementation == nil {
-		// Couldn't find the activity implementation.
+		// Report the failure to the server instead of returning an error, so the
+		// activity fails now rather than at its schedule-to-close timeout.
 		supported := strings.Join(ath.getRegisteredActivityNames(), ", ")
-		return nil, fmt.Errorf("unable to find activityType=%v. Supported types: [%v]", activityType, supported)
+		notRegistered := fmt.Errorf("unable to find activityType=%v. Supported types: [%v]", activityType, supported)
+		logger.Error("Activity error.", zap.Error(notRegistered))
+		metricsScope.Counter(metrics.ActivityExecutionFailedCounter).Inc(1)
+		return convertActivityResultToRespondRequest(ath.identity, t.TaskToken, nil, notRegistered, ath.dataConverter), nil
 	}
 
 	// panic handler

--- a/internal/activity_task_handler_test.go
+++ b/internal/activity_task_handler_test.go
@@ -235,6 +235,23 @@ func TestActivityTaskHandler_Execute_CustomError(t *testing.T) {
 	require.Equal(t, int32(30), failedRequest.GetFailureOptions().GetNextRetryIntervalSeconds())
 }
 
+func TestActivityTaskHandler_Execute_UnregisteredActivity(t *testing.T) {
+	activityHandler := newHandlerForTest(t, workerExecutionParameters{}, func(ctx context.Context) error { return nil })
+
+	pats := createBasicPollForActivityTaskResponse()
+	pats.ActivityType = &s.ActivityType{Name: common.StringPtr("notRegistered")}
+
+	res, err := activityHandler.Execute(tasklist, pats)
+	require.NoError(t, err)
+
+	failedRequest, ok := res.(*s.RespondActivityTaskFailedRequest)
+	require.True(t, ok, "response is not of type *s.RespondActivityTaskFailedRequest but of type %T", res)
+	require.Equal(t, pats.TaskToken, failedRequest.GetTaskToken())
+	require.Equal(t, errReasonGeneric, failedRequest.GetReason())
+	require.Contains(t, string(failedRequest.GetDetails()), "unable to find activityType=notRegistered")
+	require.Contains(t, string(failedRequest.GetDetails()), "activityType")
+}
+
 func newHandlerForTest(t *testing.T, params workerExecutionParameters, activityFunction any) ActivityTaskHandler {
 	registry := newRegistry()
 	err := registry.registerActivityFunction(activityFunction, RegisterActivityOptions{Name: "activityType"})

--- a/internal/internal_task_pollers_test.go
+++ b/internal/internal_task_pollers_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"github.com/uber-go/tally"
+	"go.uber.org/yarpc"
 
 	"go.uber.org/cadence/.gen/go/cadence/workflowservicetest"
 	s "go.uber.org/cadence/.gen/go/shared"
@@ -343,6 +344,51 @@ func TestActivityTaskPoller_PollTask(t *testing.T) {
 			tt.validateResult(t, result)
 		})
 	}
+}
+
+func TestActivityTaskPoller_ProcessTask_UnregisteredActivity(t *testing.T) {
+	atp, mockService := buildActivityTaskPoller(t, false)
+
+	registry := newRegistry()
+	require.NoError(t, registry.registerActivityFunction(
+		func(ctx context.Context) error { return nil },
+		RegisterActivityOptions{Name: "registered"},
+	))
+	params := workerExecutionParameters{}
+	params.WorkerOptions.Logger = testlogger.NewZap(t)
+	ensureRequiredParams(&params)
+	atp.taskHandler = newActivityTaskHandler(mockService, params, registry)
+
+	var reported *s.RespondActivityTaskFailedRequest
+	mockService.EXPECT().
+		RespondActivityTaskFailed(gomock.Any(), gomock.Any(), gomock.Any()).
+		Do(func(_ context.Context, req *s.RespondActivityTaskFailedRequest, _ ...yarpc.CallOption) {
+			reported = req
+		}).
+		Return(nil).
+		Times(1)
+
+	task := &activityTask{
+		task: &s.PollForActivityTaskResponse{
+			TaskToken:                       []byte("token"),
+			WorkflowExecution:               &s.WorkflowExecution{WorkflowId: common.StringPtr("wID"), RunId: common.StringPtr("rID")},
+			ActivityType:                    &s.ActivityType{Name: common.StringPtr("notRegistered")},
+			ActivityId:                      common.StringPtr("aID"),
+			ScheduledTimestamp:              common.Int64Ptr(time.Now().UnixNano()),
+			ScheduledTimestampOfThisAttempt: common.Int64Ptr(time.Now().UnixNano()),
+			ScheduleToCloseTimeoutSeconds:   common.Int32Ptr(1),
+			StartedTimestamp:                common.Int64Ptr(time.Now().UnixNano()),
+			StartToCloseTimeoutSeconds:      common.Int32Ptr(1),
+			Attempt:                         common.Int32Ptr(0),
+			WorkflowType:                    &s.WorkflowType{Name: common.StringPtr("wType")},
+			WorkflowDomain:                  common.StringPtr(_testDomainName),
+		},
+	}
+
+	require.NoError(t, atp.ProcessTask(task))
+	require.NotNil(t, reported, "no RespondActivityTaskFailed was sent")
+	require.Equal(t, []byte("token"), reported.GetTaskToken())
+	require.Contains(t, string(reported.GetDetails()), "unable to find activityType=notRegistered")
 }
 
 func buildActivityTaskPoller(t *testing.T, shutdown bool) (*activityTaskPoller, *workflowservicetest.MockClient) {


### PR DESCRIPTION
**What changed?**

An activity whose type is not registered on the polling worker now fails immediately. Before this change it stayed running until its schedule-to-close timeout expired, because the worker never told the server anything.

**Why?**

Fixes #1492.

Register `ActivityA` on a worker and have a workflow schedule `ActivityB` on the same task list. The worker logs `unable to find activityType=ActivityB` and sends nothing back, so the workflow blocks for the whole schedule-to-close timeout on a failure the worker already knew about at poll time. With a ten minute timeout that is ten minutes of nothing happening. The Java client responds right away here.

`Execute` returned a plain error, and `ProcessTask` reads a non-nil error as a client-side processing failure: it counts it and returns before the reporting path, so no RPC is made. The panic handler just below already returns a response with a nil error, and the unregistered case now matches it. `ActivityExecutionFailedCounter` moves into the handler so the metric survives the poller no longer seeing an error.

**How did you test it?**

Two new tests: one on the handler's request, one driving `ProcessTask` against a mock service to prove the RPC is sent. Both fail on master, the poller one on `missing call(s) to RespondActivityTaskFailed`, which is the bug itself. Full `go test ./internal/...` is green.

<details>
<summary>Red, with the handler restored from <code>upstream/master</code> (b9c7e58)</summary>

```
$ git checkout upstream/master -- internal/activity_task_handler.go
$ go test ./internal/ -run 'UnregisteredActivity' -count=1
--- FAIL: TestActivityTaskHandler_Execute_UnregisteredActivity (0.00s)
    activity_task_handler_test.go:245:
        	Error:      	Received unexpected error:
        	            	unable to find activityType=notRegistered. Supported types: [activityType]
--- FAIL: TestActivityTaskPoller_ProcessTask_UnregisteredActivity (0.00s)
    internal_task_pollers_test.go:388:
        	Error:      	Received unexpected error:
        	            	unable to find activityType=notRegistered. Supported types: [registered]
    controller.go:99: missing call(s) to *workflowservicetest.MockClient.RespondActivityTaskFailed(is anything, is anything, is anything)
    controller.go:99: aborting test due to missing call(s)
FAIL	go.uber.org/cadence/internal	0.432s
```
</details>

<details>
<summary>Green</summary>

```
$ go test ./internal/ -run 'UnregisteredActivity' -count=1 -v
=== RUN   TestActivityTaskHandler_Execute_UnregisteredActivity
    ERROR	Activity error.	{"ActivityType": "notRegistered", "error": "unable to find activityType=notRegistered. Supported types: [activityType]"}
--- PASS: TestActivityTaskHandler_Execute_UnregisteredActivity (0.00s)
=== RUN   TestActivityTaskPoller_ProcessTask_UnregisteredActivity
    ERROR	Activity error.	{"ActivityType": "notRegistered", "error": "unable to find activityType=notRegistered. Supported types: [registered]"}
--- PASS: TestActivityTaskPoller_ProcessTask_UnregisteredActivity (0.00s)
ok  	go.uber.org/cadence/internal	0.601s

$ go test ./internal/... -count=1
ok  	go.uber.org/cadence/internal	34.900s
ok  	go.uber.org/cadence/internal/batch	24.958s
ok  	go.uber.org/cadence/internal/common	0.639s
... (16 packages, all ok)
```
</details>

**Potential risks**

Low. The error text is unchanged. The behavior change is deliberate: an activity that used to hang until schedule-to-close now fails right away, as a `GenericError` carrying the same message. Retries follow the activity's retry policy, so a fleet mid-deploy with a partial registration retries rather than hangs.
