### PR TITLE
feat(workflow): WithCronSchedule for ContinueAsNew and child workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Added RequestID to StartWorkflowOptions so start and signal-with-start requests can supply an idempotency key instead of always generating a new UUID. The value must be a UUID string; the client validates it before sending.
-- `workflow.WithCronSchedule` to set a cron schedule on ContinueAsNew and child-workflow context options. Cron is not inherited from the current run; pass it explicitly to keep a schedule.
+- `workflow.WithCronSchedule` to set a cron schedule on ContinueAsNew and child-workflow context options. Cron is not inherited from the current run; pass it explicitly to keep a schedule. `WithChildOptions` copies `CronSchedule` only when it is non-empty so it does not clear a prior `WithCronSchedule`.
 
 ### Fixed
 - Skip seeding the workflow span context when the tracer is a `NoopTracer`, preventing panics for workflow tests that mix the testsuite (which defaults to `NoopTracer`) with a real tracer such as `mocktracer`. Follow-up to the span activation added in #1506 and the `NoopTracer` guard in #1516.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Added RequestID to StartWorkflowOptions so start and signal-with-start requests can supply an idempotency key instead of always generating a new UUID. The value must be a UUID string; the client validates it before sending.
+- `workflow.WithCronSchedule` to set a cron schedule on ContinueAsNew and child-workflow context options. Cron is not inherited from the current run; pass it explicitly to keep a schedule.
 
 ### Fixed
 - Skip seeding the workflow span context when the tracer is a `NoopTracer`, preventing panics for workflow tests that mix the testsuite (which defaults to `NoopTracer`) with a real tracer such as `mocktracer`. Follow-up to the span activation added in #1506 and the `NoopTracer` guard in #1516.

--- a/internal/error.go
+++ b/internal/error.go
@@ -293,11 +293,13 @@ func IsCanceledError(err error) bool {
 // the new execution with same workflow ID is started automatically with options
 // provided to this function.
 //
-//	 ctx - use context to override any options for the new workflow like execution timeout, decision task timeout, task list.
-//		  if not mentioned it would use the defaults that the current workflow is using.
+//	 ctx - use context to override any options for the new workflow like execution timeout, decision task timeout, task list, cron schedule.
+//		  if not mentioned it would use the defaults that the current workflow is using
+//		  (except cron schedule, which is not inherited; use WithCronSchedule to keep it).
 //	       ctx := WithExecutionStartToCloseTimeout(ctx, 30 * time.Minute)
 //	       ctx := WithWorkflowTaskStartToCloseTimeout(ctx, time.Minute)
 //		  ctx := WithWorkflowTaskList(ctx, "example-group")
+//		  ctx := WithCronSchedule(ctx, "* * * * *")
 //	 wfn - workflow function. for new execution it can be different from the currently running.
 //	 args - arguments for the new workflow.
 func NewContinueAsNewError(ctx Context, wfn interface{}, args ...interface{}) *ContinueAsNewError {
@@ -319,6 +321,9 @@ func NewContinueAsNewError(ctx Context, wfn interface{}, args ...interface{}) *C
 	}
 	if options.taskStartToCloseTimeoutSeconds == nil || *options.taskStartToCloseTimeoutSeconds <= 0 {
 		panic("invalid taskStartToCloseTimeoutSeconds provided")
+	}
+	if err := validateCronSchedule(options.cronSchedule); err != nil {
+		panic(err)
 	}
 
 	params := &executeWorkflowParams{

--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -1332,7 +1332,7 @@ func (wth *workflowTaskHandlerImpl) completeWorkflow(
 		// Continue as new error.
 		metricsScope.Counter(metrics.WorkflowContinueAsNewCounter).Inc(1)
 		closeDecision = createNewDecision(s.DecisionTypeContinueAsNewWorkflowExecution)
-		closeDecision.ContinueAsNewWorkflowExecutionDecisionAttributes = &s.ContinueAsNewWorkflowExecutionDecisionAttributes{
+		continueAsNewAttr := &s.ContinueAsNewWorkflowExecutionDecisionAttributes{
 			WorkflowType:                        workflowTypePtr(*contErr.params.workflowType),
 			Input:                               contErr.params.input,
 			TaskList:                            common.TaskListPtr(s.TaskList{Name: contErr.params.taskListName}),
@@ -1343,6 +1343,10 @@ func (wth *workflowTaskHandlerImpl) completeWorkflow(
 			SearchAttributes:                    workflowContext.workflowInfo.SearchAttributes,
 			RetryPolicy:                         workflowContext.workflowInfo.RetryPolicy,
 		}
+		if len(contErr.params.cronSchedule) > 0 {
+			continueAsNewAttr.CronSchedule = common.StringPtr(contErr.params.cronSchedule)
+		}
+		closeDecision.ContinueAsNewWorkflowExecutionDecisionAttributes = continueAsNewAttr
 	} else if workflowContext.err != nil {
 		// Workflow failures
 		metricsScope.Counter(metrics.WorkflowFailedCounter).Inc(1)

--- a/internal/internal_task_handlers_test.go
+++ b/internal/internal_task_handlers_test.go
@@ -1029,6 +1029,105 @@ func (t *TaskHandlersTestSuite) TestGetWorkflowInfo() {
 	t.EqualValues(retryPolicy, result.RetryPolicy)
 }
 
+func (t *TaskHandlersTestSuite) TestWorkflowTask_ContinueAsNew_WithCronSchedule() {
+	cronSchedule := "0 * * * *"
+	workflowName := "ContinueAsNewWithCronWorkflow"
+	t.registry.RegisterWorkflowWithOptions(
+		func(ctx Context) error {
+			ctx = WithCronSchedule(ctx, cronSchedule)
+			return NewContinueAsNewError(ctx, workflowName)
+		},
+		RegisterWorkflowOptions{Name: workflowName},
+	)
+
+	taskList := &s.TaskList{Name: common.StringPtr("taskList"), Kind: s.TaskListKindNormal.Ptr()}
+	var executionTimeout int32 = 10
+	var taskTimeout int32 = 1
+	testEvents := []*s.HistoryEvent{
+		createTestEventWorkflowExecutionStarted(1, &s.WorkflowExecutionStartedEventAttributes{
+			TaskList:                            taskList,
+			ExecutionStartToCloseTimeoutSeconds: &executionTimeout,
+			TaskStartToCloseTimeoutSeconds:      &taskTimeout,
+		}),
+		createTestEventDecisionTaskScheduled(2, &s.DecisionTaskScheduledEventAttributes{TaskList: taskList}),
+		createTestEventDecisionTaskStarted(3),
+	}
+	task := createWorkflowTask(testEvents, 3, workflowName)
+	params := workerExecutionParameters{
+		TaskList: taskList,
+		WorkerOptions: WorkerOptions{
+			Identity:                       "test-id-1",
+			Logger:                         zap.NewNop(),
+			NonDeterministicWorkflowPolicy: NonDeterministicWorkflowPolicyBlockWorkflow,
+		},
+	}
+
+	taskHandler := newWorkflowTaskHandler(testDomain, params, nil, t.registry)
+	request, err := taskHandler.ProcessWorkflowTask(&workflowTask{task: task}, nil)
+	t.NoError(err)
+	r, ok := request.(*s.RespondDecisionTaskCompletedRequest)
+	t.True(ok)
+	t.Equal(s.DecisionTypeContinueAsNewWorkflowExecution, r.Decisions[0].GetDecisionType())
+	attr := r.Decisions[0].ContinueAsNewWorkflowExecutionDecisionAttributes
+	t.Equal(cronSchedule, attr.GetCronSchedule())
+}
+
+func (t *TaskHandlersTestSuite) TestWorkflowTask_StartChildWorkflow_WithCronSchedule() {
+	cronSchedule := "0 * * * *"
+	childName := "NoopChildForCron"
+	parentName := "ParentStartsCronChild"
+	t.registry.RegisterWorkflowWithOptions(
+		func(ctx Context) error { return nil },
+		RegisterWorkflowOptions{Name: childName},
+	)
+	t.registry.RegisterWorkflowWithOptions(
+		func(ctx Context) error {
+			ctx = WithCronSchedule(ctx, cronSchedule)
+			ExecuteChildWorkflow(ctx, childName)
+			return nil
+		},
+		RegisterWorkflowOptions{Name: parentName},
+	)
+
+	taskList := &s.TaskList{Name: common.StringPtr("taskList"), Kind: s.TaskListKindNormal.Ptr()}
+	var executionTimeout int32 = 10
+	var taskTimeout int32 = 1
+	testEvents := []*s.HistoryEvent{
+		createTestEventWorkflowExecutionStarted(1, &s.WorkflowExecutionStartedEventAttributes{
+			TaskList:                            taskList,
+			ExecutionStartToCloseTimeoutSeconds: &executionTimeout,
+			TaskStartToCloseTimeoutSeconds:      &taskTimeout,
+		}),
+		createTestEventDecisionTaskScheduled(2, &s.DecisionTaskScheduledEventAttributes{TaskList: taskList}),
+		createTestEventDecisionTaskStarted(3),
+	}
+	task := createWorkflowTask(testEvents, 3, parentName)
+	params := workerExecutionParameters{
+		TaskList: taskList,
+		WorkerOptions: WorkerOptions{
+			Identity:                       "test-id-1",
+			Logger:                         zap.NewNop(),
+			NonDeterministicWorkflowPolicy: NonDeterministicWorkflowPolicyBlockWorkflow,
+		},
+	}
+
+	taskHandler := newWorkflowTaskHandler(testDomain, params, nil, t.registry)
+	request, err := taskHandler.ProcessWorkflowTask(&workflowTask{task: task}, nil)
+	t.NoError(err)
+	r, ok := request.(*s.RespondDecisionTaskCompletedRequest)
+	t.True(ok)
+
+	var childAttr *s.StartChildWorkflowExecutionDecisionAttributes
+	for _, d := range r.Decisions {
+		if d.GetDecisionType() == s.DecisionTypeStartChildWorkflowExecution {
+			childAttr = d.StartChildWorkflowExecutionDecisionAttributes
+			break
+		}
+	}
+	t.NotNil(childAttr)
+	t.Equal(cronSchedule, childAttr.GetCronSchedule())
+}
+
 func (t *TaskHandlersTestSuite) TestConsistentQuery_InvalidQueryTask() {
 	taskList := &s.TaskList{Name: common.StringPtr("taskList"), Kind: s.TaskListKindNormal.Ptr()}
 	params := workerExecutionParameters{

--- a/internal/internal_workflow_test.go
+++ b/internal/internal_workflow_test.go
@@ -509,13 +509,13 @@ func (s *WorkflowUnitTest) Test_WithCronSchedule_SetsChildWorkflowOptions() {
 	s.Equal(cron, gotCron)
 }
 
-func (s *WorkflowUnitTest) Test_WithChildWorkflowOptions_OverwritesCronSchedule() {
+func (s *WorkflowUnitTest) Test_WithChildWorkflowOptions_PreservesCronScheduleWhenEmpty() {
+	const cron = "*/5 * * * *"
 	var gotCron string
 	testWorkflow := func(ctx Context) error {
-		ctx = WithCronSchedule(ctx, "0 * * * *")
+		ctx = WithCronSchedule(ctx, cron)
 		ctx = WithChildWorkflowOptions(ctx, ChildWorkflowOptions{
 			ExecutionStartToCloseTimeout: time.Minute,
-			CronSchedule:                 "",
 		})
 		opts, err := getValidatedWorkflowOptions(ctx)
 		if err != nil {
@@ -529,7 +529,31 @@ func (s *WorkflowUnitTest) Test_WithChildWorkflowOptions_OverwritesCronSchedule(
 	env.ExecuteWorkflow(testWorkflow)
 	s.True(env.IsWorkflowCompleted())
 	s.NoError(env.GetWorkflowError())
-	s.Empty(gotCron)
+	s.Equal(cron, gotCron)
+}
+
+func (s *WorkflowUnitTest) Test_WithChildWorkflowOptions_SetsCronScheduleWhenNonEmpty() {
+	const cron = "*/5 * * * *"
+	var gotCron string
+	testWorkflow := func(ctx Context) error {
+		ctx = WithCronSchedule(ctx, "0 * * * *")
+		ctx = WithChildWorkflowOptions(ctx, ChildWorkflowOptions{
+			ExecutionStartToCloseTimeout: time.Minute,
+			CronSchedule:                 cron,
+		})
+		opts, err := getValidatedWorkflowOptions(ctx)
+		if err != nil {
+			return err
+		}
+		gotCron = opts.cronSchedule
+		return nil
+	}
+
+	env := newTestWorkflowEnv(s.T())
+	env.ExecuteWorkflow(testWorkflow)
+	s.True(env.IsWorkflowCompleted())
+	s.NoError(env.GetWorkflowError())
+	s.Equal(cron, gotCron)
 }
 
 func cancelWorkflowTest(ctx Context) (string, error) {

--- a/internal/internal_workflow_test.go
+++ b/internal/internal_workflow_test.go
@@ -473,6 +473,63 @@ func (s *WorkflowUnitTest) Test_ContinueAsNewWorkflow() {
 	s.EqualValues(1, *resultErr.params.executionStartToCloseTimeoutSeconds)
 	s.EqualValues(1, *resultErr.params.taskStartToCloseTimeoutSeconds)
 	s.EqualValues("default-test-tasklist", *resultErr.params.taskListName)
+	s.Empty(resultErr.params.cronSchedule)
+}
+
+func continueAsNewWorkflowWithCronTest(ctx Context) error {
+	ctx = WithCronSchedule(ctx, "0 * * * *")
+	return NewContinueAsNewError(ctx, "continueAsNewWorkflowWithCronTest")
+}
+
+func (s *WorkflowUnitTest) Test_ContinueAsNewWorkflow_WithCronSchedule() {
+	env := newTestWorkflowEnv(s.T())
+	env.ExecuteWorkflow(continueAsNewWorkflowWithCronTest)
+	s.True(env.IsWorkflowCompleted())
+	resultErr := env.GetWorkflowError().(*ContinueAsNewError)
+	s.Equal("0 * * * *", resultErr.params.cronSchedule)
+}
+
+func (s *WorkflowUnitTest) Test_WithCronSchedule_SetsChildWorkflowOptions() {
+	const cron = "*/5 * * * *"
+	var gotCron string
+	testWorkflow := func(ctx Context) error {
+		ctx = WithCronSchedule(ctx, cron)
+		opts, err := getValidatedWorkflowOptions(ctx)
+		if err != nil {
+			return err
+		}
+		gotCron = opts.cronSchedule
+		return nil
+	}
+
+	env := newTestWorkflowEnv(s.T())
+	env.ExecuteWorkflow(testWorkflow)
+	s.True(env.IsWorkflowCompleted())
+	s.NoError(env.GetWorkflowError())
+	s.Equal(cron, gotCron)
+}
+
+func (s *WorkflowUnitTest) Test_WithChildWorkflowOptions_OverwritesCronSchedule() {
+	var gotCron string
+	testWorkflow := func(ctx Context) error {
+		ctx = WithCronSchedule(ctx, "0 * * * *")
+		ctx = WithChildWorkflowOptions(ctx, ChildWorkflowOptions{
+			ExecutionStartToCloseTimeout: time.Minute,
+			CronSchedule:                 "",
+		})
+		opts, err := getValidatedWorkflowOptions(ctx)
+		if err != nil {
+			return err
+		}
+		gotCron = opts.cronSchedule
+		return nil
+	}
+
+	env := newTestWorkflowEnv(s.T())
+	env.ExecuteWorkflow(testWorkflow)
+	s.True(env.IsWorkflowCompleted())
+	s.NoError(env.GetWorkflowError())
+	s.Empty(gotCron)
 }
 
 func cancelWorkflowTest(ctx Context) (string, error) {

--- a/internal/internal_workflow_test.go
+++ b/internal/internal_workflow_test.go
@@ -509,6 +509,27 @@ func (s *WorkflowUnitTest) Test_WithCronSchedule_SetsChildWorkflowOptions() {
 	s.Equal(cron, gotCron)
 }
 
+func (s *WorkflowUnitTest) Test_WithCronSchedule_ClearsCronScheduleWhenEmpty() {
+	const cron = "*/5 * * * *"
+	var gotCron string
+	testWorkflow := func(ctx Context) error {
+		ctx = WithCronSchedule(ctx, cron)
+		ctx = WithCronSchedule(ctx, "")
+		opts, err := getValidatedWorkflowOptions(ctx)
+		if err != nil {
+			return err
+		}
+		gotCron = opts.cronSchedule
+		return nil
+	}
+
+	env := newTestWorkflowEnv(s.T())
+	env.ExecuteWorkflow(testWorkflow)
+	s.True(env.IsWorkflowCompleted())
+	s.NoError(env.GetWorkflowError())
+	s.Empty(gotCron)
+}
+
 func (s *WorkflowUnitTest) Test_WithChildWorkflowOptions_PreservesCronScheduleWhenEmpty() {
 	const cron = "*/5 * * * *"
 	var gotCron string

--- a/internal/workflow.go
+++ b/internal/workflow.go
@@ -1445,6 +1445,24 @@ func WithWorkflowTaskList(ctx Context, name string) Context {
 	return ctx1
 }
 
+// WithCronSchedule sets a cron schedule on the context.
+//
+// The same workflow options are used for ContinueAsNew (via NewContinueAsNewError)
+// and for child workflows (via ExecuteChildWorkflow). Cron is not copied from the
+// current run automatically; pass it explicitly when the next run or child should
+// keep a schedule.
+//
+// WithChildWorkflowOptions overwrites this field with ChildWorkflowOptions.CronSchedule.
+// Apply WithCronSchedule after WithChildWorkflowOptions if both are used.
+//
+// An empty schedule clears a previously set value. Invalid specs are rejected when
+// ContinueAsNew or child workflow options are validated.
+func WithCronSchedule(ctx Context, cronSchedule string) Context {
+	ctx1 := setWorkflowEnvOptionsIfNotExist(ctx)
+	getWorkflowEnvOptions(ctx1).cronSchedule = cronSchedule
+	return ctx1
+}
+
 // GetWorkflowTaskList retrieves current workflow tasklist from context
 func GetWorkflowTaskList(ctx Context) *string {
 	wo := getWorkflowEnvOptions(ctx)

--- a/internal/workflow.go
+++ b/internal/workflow.go
@@ -1411,6 +1411,11 @@ func (wc *workflowEnvironmentInterceptor) UpsertSearchAttributes(ctx Context, at
 // WithChildWorkflowOptions adds all workflow options to the context.
 // The current timeout resolution implementation is in seconds and uses math.Ceil(d.Seconds()) as the duration. But is
 // subjected to change in the future.
+//
+// CronSchedule is applied only when non-empty so a prior WithCronSchedule is not
+// cleared by typical child options (timeouts, task list, and so on). Pass a
+// non-empty CronSchedule here to set or replace it, or WithCronSchedule(ctx, "")
+// to clear it.
 func WithChildWorkflowOptions(ctx Context, cwo ChildWorkflowOptions) Context {
 	ctx1 := setWorkflowEnvOptionsIfNotExist(ctx)
 	wfOptions := getWorkflowEnvOptions(ctx1)
@@ -1422,7 +1427,9 @@ func WithChildWorkflowOptions(ctx Context, cwo ChildWorkflowOptions) Context {
 	wfOptions.waitForCancellation = cwo.WaitForCancellation
 	wfOptions.workflowIDReusePolicy = cwo.WorkflowIDReusePolicy
 	wfOptions.retryPolicy = convertRetryPolicy(cwo.RetryPolicy)
-	wfOptions.cronSchedule = cwo.CronSchedule
+	if cwo.CronSchedule != "" {
+		wfOptions.cronSchedule = cwo.CronSchedule
+	}
 	wfOptions.memo = cwo.Memo
 	wfOptions.searchAttributes = cwo.SearchAttributes
 	wfOptions.parentClosePolicy = cwo.ParentClosePolicy
@@ -1452,11 +1459,11 @@ func WithWorkflowTaskList(ctx Context, name string) Context {
 // current run automatically; pass it explicitly when the next run or child should
 // keep a schedule.
 //
-// WithChildWorkflowOptions overwrites this field with ChildWorkflowOptions.CronSchedule.
-// Apply WithCronSchedule after WithChildWorkflowOptions if both are used.
-//
-// An empty schedule clears a previously set value. Invalid specs are rejected when
-// ContinueAsNew or child workflow options are validated.
+// ChildWorkflowOptions.CronSchedule is applied only when non-empty, so
+// WithCronSchedule then WithChildWorkflowOptions still keeps the schedule.
+// A non-empty ChildWorkflowOptions.CronSchedule replaces it. Pass "" here to
+// clear a previously set value. Invalid specs are rejected when ContinueAsNew
+// or child workflow options are validated.
 func WithCronSchedule(ctx Context, cronSchedule string) Context {
 	ctx1 := setWorkflowEnvOptionsIfNotExist(ctx)
 	getWorkflowEnvOptions(ctx1).cronSchedule = cronSchedule

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -264,92 +264,45 @@ func (ts *IntegrationTestSuite) TestContinueAsNewCarryOver() {
 }
 
 func (ts *IntegrationTestSuite) TestContinueAsNewWithCronSchedule() {
-	const cron = "* * * * *"
-	wfID := "test-continueasnew-cronschedule"
-	defer func() {
-		ctx, cancel := context.WithTimeout(context.Background(), ctxTimeout)
-		defer cancel()
-		_ = ts.libClient.TerminateWorkflow(ctx, wfID, "", "integration test cleanup", nil)
-	}()
-
-	startOptions := ts.startWorkflowOptions(wfID)
-	startOptions.CronSchedule = cron
-
-	var result string
-	execution, err := ts.executeWorkflowWithOption(startOptions, ts.workflows.ContinueAsNewWithCronSchedule, &result, 1, ts.taskListName, cron)
-	ts.NoError(err)
-	ts.Equal(cron, result)
+	wfID := "test-continueasnew-cronschedule-" + uuid.New()
+	defer ts.terminateWorkflows(wfID)
 
 	ctx, cancel := context.WithTimeout(context.Background(), ctxTimeout)
 	defer cancel()
 
-	iter := ts.libClient.GetWorkflowHistory(ctx, wfID, execution.RunID, false, shared.HistoryEventFilterTypeAllEvent)
-	var continuedAsNew *shared.HistoryEvent
-	for iter.HasNext() {
-		event, err := iter.Next()
-		ts.NoError(err)
-		if event.GetEventType() == shared.EventTypeWorkflowExecutionContinuedAsNew {
-			continuedAsNew = event
-			break
-		}
-	}
-	ts.NotNil(continuedAsNew)
-	secondRunID := continuedAsNew.WorkflowExecutionContinuedAsNewEventAttributes.GetNewExecutionRunId()
-	ts.NotEmpty(secondRunID)
+	// The workflow is started on a schedule that fires within seconds and passes on a
+	// different one, so the schedule on the next run can only come from WithCronSchedule.
+	startOptions := ts.startWorkflowOptions(wfID)
+	startOptions.CronSchedule = frequentCronSchedule
 
-	iter = ts.libClient.GetWorkflowHistory(ctx, wfID, secondRunID, false, shared.HistoryEventFilterTypeAllEvent)
-	ts.True(iter.HasNext())
-	started, err := iter.Next()
+	// The workflow continues as new indefinitely, so assert on history rather than a result.
+	execution, err := ts.libClient.StartWorkflow(ctx, startOptions, ts.workflows.ContinueAsNewWithCronSchedule)
 	ts.NoError(err)
-	ts.Equal(shared.EventTypeWorkflowExecutionStarted, started.GetEventType())
-	ts.Equal(cron, started.WorkflowExecutionStartedEventAttributes.GetCronSchedule())
+
+	secondRunID := ts.continuedAsNewRunID(ctx, wfID, execution.RunID)
+	started := ts.waitForHistoryEvent(ctx, wfID, secondRunID, shared.EventTypeWorkflowExecutionStarted)
+	ts.Equal(rareCronSchedule, started.WorkflowExecutionStartedEventAttributes.GetCronSchedule())
 }
 
 func (ts *IntegrationTestSuite) TestContinueAsNewInCronWithoutWithCronSchedule() {
-	const cron = "* * * * *"
-	wfID := "test-continueasnew-cron-without-withcronschedule"
-	defer func() {
-		ctx, cancel := context.WithTimeout(context.Background(), ctxTimeout)
-		defer cancel()
-		_ = ts.libClient.TerminateWorkflow(ctx, wfID, "", "integration test cleanup", nil)
-	}()
-
-	startOptions := ts.startWorkflowOptions(wfID)
-	startOptions.CronSchedule = cron
-
-	var result string
-	execution, err := ts.executeWorkflowWithOption(startOptions, ts.workflows.ContinueAsNewWithoutCronSchedule, &result, 1, ts.taskListName)
-	ts.NoError(err)
-	ts.Empty(result)
+	wfID := "test-continueasnew-cron-without-withcronschedule-" + uuid.New()
+	defer ts.terminateWorkflows(wfID)
 
 	ctx, cancel := context.WithTimeout(context.Background(), ctxTimeout)
 	defer cancel()
 
-	iter := ts.libClient.GetWorkflowHistory(ctx, wfID, execution.RunID, false, shared.HistoryEventFilterTypeAllEvent)
-	ts.True(iter.HasNext())
-	started, err := iter.Next()
-	ts.NoError(err)
-	ts.Equal(shared.EventTypeWorkflowExecutionStarted, started.GetEventType())
-	ts.Equal(cron, started.WorkflowExecutionStartedEventAttributes.GetCronSchedule())
+	startOptions := ts.startWorkflowOptions(wfID)
+	startOptions.CronSchedule = frequentCronSchedule
 
-	var continuedAsNew *shared.HistoryEvent
-	for iter.HasNext() {
-		event, err := iter.Next()
-		ts.NoError(err)
-		if event.GetEventType() == shared.EventTypeWorkflowExecutionContinuedAsNew {
-			continuedAsNew = event
-			break
-		}
-	}
-	ts.NotNil(continuedAsNew)
-	secondRunID := continuedAsNew.WorkflowExecutionContinuedAsNewEventAttributes.GetNewExecutionRunId()
-	ts.NotEmpty(secondRunID)
-
-	iter = ts.libClient.GetWorkflowHistory(ctx, wfID, secondRunID, false, shared.HistoryEventFilterTypeAllEvent)
-	ts.True(iter.HasNext())
-	started, err = iter.Next()
+	// The workflow continues as new indefinitely, so assert on history rather than a result.
+	execution, err := ts.libClient.StartWorkflow(ctx, startOptions, ts.workflows.ContinueAsNewWithoutCronSchedule)
 	ts.NoError(err)
-	ts.Equal(shared.EventTypeWorkflowExecutionStarted, started.GetEventType())
+
+	started := ts.waitForHistoryEvent(ctx, wfID, execution.RunID, shared.EventTypeWorkflowExecutionStarted)
+	ts.Equal(frequentCronSchedule, started.WorkflowExecutionStartedEventAttributes.GetCronSchedule())
+
+	nextRunID := ts.continuedAsNewRunID(ctx, wfID, execution.RunID)
+	started = ts.waitForHistoryEvent(ctx, wfID, nextRunID, shared.EventTypeWorkflowExecutionStarted)
 	ts.Empty(started.WorkflowExecutionStartedEventAttributes.GetCronSchedule())
 }
 
@@ -556,79 +509,54 @@ func (ts *IntegrationTestSuite) TestChildWFWithMemoAndSearchAttributes() {
 }
 
 func (ts *IntegrationTestSuite) TestChildWorkflowsWithCronSchedule() {
-	const cron = "* * * * *"
-	parentID := "test-childwf-with-cronschedule"
+	parentID := "test-childwf-with-cronschedule-" + uuid.New()
 	childID := parentID + "-child"
-	defer func() {
-		ctx, cancel := context.WithTimeout(context.Background(), ctxTimeout)
-		defer cancel()
-		_ = ts.libClient.TerminateWorkflow(ctx, parentID, "", "integration test cleanup", nil)
-		_ = ts.libClient.TerminateWorkflow(ctx, childID, "", "integration test cleanup", nil)
-	}()
+	defer ts.terminateWorkflows(parentID, childID)
 
-	var result string
-	execution, err := ts.executeWorkflow(parentID, ts.workflows.ChildWorkflowsWithCronSchedule, &result, childID, cron)
+	// The parent returns as soon as the cron child has started, so the child itself never runs.
+	var childRunID string
+	execution, err := ts.executeWorkflow(parentID, ts.workflows.ChildWorkflowsWithCronSchedule, &childRunID, childID)
 	ts.NoError(err)
-	ts.Equal(cron, result)
+	ts.NotEmpty(childRunID)
 
 	ctx, cancel := context.WithTimeout(context.Background(), ctxTimeout)
 	defer cancel()
-	ts.assertChildCronSchedule(ctx, execution.ID, execution.RunID, childID, cron)
+
+	initiated := ts.waitForHistoryEvent(ctx, parentID, execution.RunID, shared.EventTypeStartChildWorkflowExecutionInitiated)
+	ts.Equal(childID, initiated.StartChildWorkflowExecutionInitiatedEventAttributes.GetWorkflowId())
+	ts.Equal(rareCronSchedule, initiated.StartChildWorkflowExecutionInitiatedEventAttributes.GetCronSchedule())
+
+	started := ts.waitForHistoryEvent(ctx, childID, childRunID, shared.EventTypeWorkflowExecutionStarted)
+	ts.Equal(rareCronSchedule, started.WorkflowExecutionStartedEventAttributes.GetCronSchedule())
 }
 
 func (ts *IntegrationTestSuite) TestChildWorkflowsWithoutWithCronSchedule() {
-	const cron = "* * * * *"
-	parentID := "test-childwf-without-withcronschedule"
+	parentID := "test-childwf-without-withcronschedule-" + uuid.New()
 	childID := parentID + "-child"
-	defer func() {
-		ctx, cancel := context.WithTimeout(context.Background(), ctxTimeout)
-		defer cancel()
-		_ = ts.libClient.TerminateWorkflow(ctx, parentID, "", "integration test cleanup", nil)
-		_ = ts.libClient.TerminateWorkflow(ctx, childID, "", "integration test cleanup", nil)
-	}()
-
-	startOptions := ts.startWorkflowOptions(parentID)
-	startOptions.CronSchedule = cron
-
-	var result string
-	execution, err := ts.executeWorkflowWithOption(startOptions, ts.workflows.ChildWorkflowsWithoutWithCronSchedule, &result, childID)
-	ts.NoError(err)
-	ts.Empty(result)
+	defer ts.terminateWorkflows(parentID, childID)
 
 	ctx, cancel := context.WithTimeout(context.Background(), ctxTimeout)
 	defer cancel()
 
-	iter := ts.libClient.GetWorkflowHistory(ctx, execution.ID, execution.RunID, false, shared.HistoryEventFilterTypeAllEvent)
-	ts.True(iter.HasNext())
-	started, err := iter.Next()
+	// The run that starts the child has a cron schedule, so its own completion continues the
+	// chain as new rather than closing the workflow. Assert on history instead of the result.
+	execution, err := ts.libClient.StartWorkflow(ctx, ts.startWorkflowOptions(parentID), ts.workflows.ChildWorkflowsWithoutWithCronSchedule, childID)
 	ts.NoError(err)
-	ts.Equal(shared.EventTypeWorkflowExecutionStarted, started.GetEventType())
-	ts.Equal(cron, started.WorkflowExecutionStartedEventAttributes.GetCronSchedule())
 
-	ts.assertChildCronSchedule(ctx, execution.ID, execution.RunID, childID, "")
-}
+	cronRunID := ts.continuedAsNewRunID(ctx, parentID, execution.RunID)
+	started := ts.waitForHistoryEvent(ctx, parentID, cronRunID, shared.EventTypeWorkflowExecutionStarted)
+	ts.Equal(rareCronSchedule, started.WorkflowExecutionStartedEventAttributes.GetCronSchedule())
 
-func (ts *IntegrationTestSuite) assertChildCronSchedule(ctx context.Context, parentID, parentRunID, childID, wantCron string) {
-	iter := ts.libClient.GetWorkflowHistory(ctx, parentID, parentRunID, false, shared.HistoryEventFilterTypeAllEvent)
-	var initiated *shared.HistoryEvent
-	for iter.HasNext() {
-		event, err := iter.Next()
-		ts.NoError(err)
-		if event.GetEventType() == shared.EventTypeStartChildWorkflowExecutionInitiated {
-			initiated = event
-			break
-		}
-	}
-	ts.NotNil(initiated)
+	initiated := ts.waitForHistoryEvent(ctx, parentID, cronRunID, shared.EventTypeStartChildWorkflowExecutionInitiated)
 	ts.Equal(childID, initiated.StartChildWorkflowExecutionInitiatedEventAttributes.GetWorkflowId())
-	ts.Equal(wantCron, initiated.StartChildWorkflowExecutionInitiatedEventAttributes.GetCronSchedule())
+	ts.Empty(initiated.StartChildWorkflowExecutionInitiatedEventAttributes.GetCronSchedule())
 
-	iter = ts.libClient.GetWorkflowHistory(ctx, childID, "", false, shared.HistoryEventFilterTypeAllEvent)
-	ts.True(iter.HasNext())
-	started, err := iter.Next()
-	ts.NoError(err)
-	ts.Equal(shared.EventTypeWorkflowExecutionStarted, started.GetEventType())
-	ts.Equal(wantCron, started.WorkflowExecutionStartedEventAttributes.GetCronSchedule())
+	childStarted := ts.waitForHistoryEvent(ctx, parentID, cronRunID, shared.EventTypeChildWorkflowExecutionStarted)
+	childRunID := childStarted.ChildWorkflowExecutionStartedEventAttributes.GetWorkflowExecution().GetRunId()
+	ts.NotEmpty(childRunID)
+
+	started = ts.waitForHistoryEvent(ctx, childID, childRunID, shared.EventTypeWorkflowExecutionStarted)
+	ts.Empty(started.WorkflowExecutionStartedEventAttributes.GetCronSchedule())
 }
 
 func (ts *IntegrationTestSuite) TestChildWFWithParentClosePolicyTerminate() {
@@ -1022,6 +950,48 @@ func (ts *IntegrationTestSuite) startWorkflowOptions(wfID string) client.StartWo
 func (ts *IntegrationTestSuite) registerWorkflowsAndActivities(w worker.Worker) {
 	ts.workflows.register(w)
 	ts.activities.register(w)
+}
+
+// waitForHistoryEvent polls a single run's history until it contains an event of the given
+// type. Runs with a cron schedule never close on their own, so cron tests assert on the
+// events of a specific run rather than waiting for a result.
+func (ts *IntegrationTestSuite) waitForHistoryEvent(ctx context.Context, wfID, runID string, eventType shared.EventType) *shared.HistoryEvent {
+	for {
+		iter := ts.libClient.GetWorkflowHistory(ctx, wfID, runID, false, shared.HistoryEventFilterTypeAllEvent)
+		for iter.HasNext() {
+			event, err := iter.Next()
+			ts.NoError(err)
+			if event.GetEventType() == eventType {
+				return event
+			}
+		}
+
+		select {
+		case <-ctx.Done():
+			ts.FailNowf("history event not found",
+				"%v never appeared in run %v of workflow %v", eventType, runID, wfID)
+			return nil
+		case <-time.After(250 * time.Millisecond):
+		}
+	}
+}
+
+// continuedAsNewRunID returns the run ID that the given run continued as new into.
+func (ts *IntegrationTestSuite) continuedAsNewRunID(ctx context.Context, wfID, runID string) string {
+	event := ts.waitForHistoryEvent(ctx, wfID, runID, shared.EventTypeWorkflowExecutionContinuedAsNew)
+	newRunID := event.WorkflowExecutionContinuedAsNewEventAttributes.GetNewExecutionRunId()
+	ts.NotEmpty(newRunID)
+	return newRunID
+}
+
+// terminateWorkflows closes out workflows that outlive a test, such as cron chains that
+// would otherwise keep scheduling runs.
+func (ts *IntegrationTestSuite) terminateWorkflows(wfIDs ...string) {
+	ctx, cancel := context.WithTimeout(context.Background(), ctxTimeout)
+	defer cancel()
+	for _, wfID := range wfIDs {
+		_ = ts.libClient.TerminateWorkflow(ctx, wfID, "", "integration test cleanup", nil)
+	}
 }
 
 func (ts *IntegrationTestSuite) waitForWorkflowFinish(wid string, runID string) error {

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -264,7 +264,7 @@ func (ts *IntegrationTestSuite) TestContinueAsNewCarryOver() {
 }
 
 func (ts *IntegrationTestSuite) TestContinueAsNewWithCronSchedule() {
-	const cron = "0 0 1 1 *"
+	const cron = "* * * * *"
 	wfID := "test-continueasnew-cronschedule"
 	defer func() {
 		ctx, cancel := context.WithTimeout(context.Background(), ctxTimeout)
@@ -306,7 +306,7 @@ func (ts *IntegrationTestSuite) TestContinueAsNewWithCronSchedule() {
 }
 
 func (ts *IntegrationTestSuite) TestContinueAsNewInCronWithoutWithCronSchedule() {
-	const cron = "0 0 1 1 *"
+	const cron = "* * * * *"
 	wfID := "test-continueasnew-cron-without-withcronschedule"
 	defer func() {
 		ctx, cancel := context.WithTimeout(context.Background(), ctxTimeout)
@@ -553,6 +553,82 @@ func (ts *IntegrationTestSuite) TestChildWFWithMemoAndSearchAttributes() {
 	ts.Equal("memoVal, searchAttrVal", result)
 	ts.Equal([]string{"ExecuteWorkflow begin", "ExecuteChildWorkflow", "ExecuteWorkflow end"},
 		ts.tracer.GetTrace("go.uber.org/cadence/test.(*Workflows).ChildWorkflowSuccess"))
+}
+
+func (ts *IntegrationTestSuite) TestChildWorkflowsWithCronSchedule() {
+	const cron = "* * * * *"
+	parentID := "test-childwf-with-cronschedule"
+	childID := parentID + "-child"
+	defer func() {
+		ctx, cancel := context.WithTimeout(context.Background(), ctxTimeout)
+		defer cancel()
+		_ = ts.libClient.TerminateWorkflow(ctx, parentID, "", "integration test cleanup", nil)
+		_ = ts.libClient.TerminateWorkflow(ctx, childID, "", "integration test cleanup", nil)
+	}()
+
+	var result string
+	execution, err := ts.executeWorkflow(parentID, ts.workflows.ChildWorkflowsWithCronSchedule, &result, childID, cron)
+	ts.NoError(err)
+	ts.Equal(cron, result)
+
+	ctx, cancel := context.WithTimeout(context.Background(), ctxTimeout)
+	defer cancel()
+	ts.assertChildCronSchedule(ctx, execution.ID, execution.RunID, childID, cron)
+}
+
+func (ts *IntegrationTestSuite) TestChildWorkflowsWithoutWithCronSchedule() {
+	const cron = "* * * * *"
+	parentID := "test-childwf-without-withcronschedule"
+	childID := parentID + "-child"
+	defer func() {
+		ctx, cancel := context.WithTimeout(context.Background(), ctxTimeout)
+		defer cancel()
+		_ = ts.libClient.TerminateWorkflow(ctx, parentID, "", "integration test cleanup", nil)
+		_ = ts.libClient.TerminateWorkflow(ctx, childID, "", "integration test cleanup", nil)
+	}()
+
+	startOptions := ts.startWorkflowOptions(parentID)
+	startOptions.CronSchedule = cron
+
+	var result string
+	execution, err := ts.executeWorkflowWithOption(startOptions, ts.workflows.ChildWorkflowsWithoutWithCronSchedule, &result, childID)
+	ts.NoError(err)
+	ts.Empty(result)
+
+	ctx, cancel := context.WithTimeout(context.Background(), ctxTimeout)
+	defer cancel()
+
+	iter := ts.libClient.GetWorkflowHistory(ctx, execution.ID, execution.RunID, false, shared.HistoryEventFilterTypeAllEvent)
+	ts.True(iter.HasNext())
+	started, err := iter.Next()
+	ts.NoError(err)
+	ts.Equal(shared.EventTypeWorkflowExecutionStarted, started.GetEventType())
+	ts.Equal(cron, started.WorkflowExecutionStartedEventAttributes.GetCronSchedule())
+
+	ts.assertChildCronSchedule(ctx, execution.ID, execution.RunID, childID, "")
+}
+
+func (ts *IntegrationTestSuite) assertChildCronSchedule(ctx context.Context, parentID, parentRunID, childID, wantCron string) {
+	iter := ts.libClient.GetWorkflowHistory(ctx, parentID, parentRunID, false, shared.HistoryEventFilterTypeAllEvent)
+	var initiated *shared.HistoryEvent
+	for iter.HasNext() {
+		event, err := iter.Next()
+		ts.NoError(err)
+		if event.GetEventType() == shared.EventTypeStartChildWorkflowExecutionInitiated {
+			initiated = event
+			break
+		}
+	}
+	ts.NotNil(initiated)
+	ts.Equal(childID, initiated.StartChildWorkflowExecutionInitiatedEventAttributes.GetWorkflowId())
+	ts.Equal(wantCron, initiated.StartChildWorkflowExecutionInitiatedEventAttributes.GetCronSchedule())
+
+	iter = ts.libClient.GetWorkflowHistory(ctx, childID, "", false, shared.HistoryEventFilterTypeAllEvent)
+	ts.True(iter.HasNext())
+	started, err := iter.Next()
+	ts.NoError(err)
+	ts.Equal(shared.EventTypeWorkflowExecutionStarted, started.GetEventType())
+	ts.Equal(wantCron, started.WorkflowExecutionStartedEventAttributes.GetCronSchedule())
 }
 
 func (ts *IntegrationTestSuite) TestChildWFWithParentClosePolicyTerminate() {

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -263,6 +263,96 @@ func (ts *IntegrationTestSuite) TestContinueAsNewCarryOver() {
 	ts.Equal("memoVal,searchAttr", result)
 }
 
+func (ts *IntegrationTestSuite) TestContinueAsNewWithCronSchedule() {
+	const cron = "0 0 1 1 *"
+	wfID := "test-continueasnew-cronschedule"
+	defer func() {
+		ctx, cancel := context.WithTimeout(context.Background(), ctxTimeout)
+		defer cancel()
+		_ = ts.libClient.TerminateWorkflow(ctx, wfID, "", "integration test cleanup", nil)
+	}()
+
+	startOptions := ts.startWorkflowOptions(wfID)
+	startOptions.CronSchedule = cron
+
+	var result string
+	execution, err := ts.executeWorkflowWithOption(startOptions, ts.workflows.ContinueAsNewWithCronSchedule, &result, 1, ts.taskListName, cron)
+	ts.NoError(err)
+	ts.Equal(cron, result)
+
+	ctx, cancel := context.WithTimeout(context.Background(), ctxTimeout)
+	defer cancel()
+
+	iter := ts.libClient.GetWorkflowHistory(ctx, wfID, execution.RunID, false, shared.HistoryEventFilterTypeAllEvent)
+	var continuedAsNew *shared.HistoryEvent
+	for iter.HasNext() {
+		event, err := iter.Next()
+		ts.NoError(err)
+		if event.GetEventType() == shared.EventTypeWorkflowExecutionContinuedAsNew {
+			continuedAsNew = event
+			break
+		}
+	}
+	ts.NotNil(continuedAsNew)
+	secondRunID := continuedAsNew.WorkflowExecutionContinuedAsNewEventAttributes.GetNewExecutionRunId()
+	ts.NotEmpty(secondRunID)
+
+	iter = ts.libClient.GetWorkflowHistory(ctx, wfID, secondRunID, false, shared.HistoryEventFilterTypeAllEvent)
+	ts.True(iter.HasNext())
+	started, err := iter.Next()
+	ts.NoError(err)
+	ts.Equal(shared.EventTypeWorkflowExecutionStarted, started.GetEventType())
+	ts.Equal(cron, started.WorkflowExecutionStartedEventAttributes.GetCronSchedule())
+}
+
+func (ts *IntegrationTestSuite) TestContinueAsNewInCronWithoutWithCronSchedule() {
+	const cron = "0 0 1 1 *"
+	wfID := "test-continueasnew-cron-without-withcronschedule"
+	defer func() {
+		ctx, cancel := context.WithTimeout(context.Background(), ctxTimeout)
+		defer cancel()
+		_ = ts.libClient.TerminateWorkflow(ctx, wfID, "", "integration test cleanup", nil)
+	}()
+
+	startOptions := ts.startWorkflowOptions(wfID)
+	startOptions.CronSchedule = cron
+
+	var result string
+	execution, err := ts.executeWorkflowWithOption(startOptions, ts.workflows.ContinueAsNewWithoutCronSchedule, &result, 1, ts.taskListName)
+	ts.NoError(err)
+	ts.Empty(result)
+
+	ctx, cancel := context.WithTimeout(context.Background(), ctxTimeout)
+	defer cancel()
+
+	iter := ts.libClient.GetWorkflowHistory(ctx, wfID, execution.RunID, false, shared.HistoryEventFilterTypeAllEvent)
+	ts.True(iter.HasNext())
+	started, err := iter.Next()
+	ts.NoError(err)
+	ts.Equal(shared.EventTypeWorkflowExecutionStarted, started.GetEventType())
+	ts.Equal(cron, started.WorkflowExecutionStartedEventAttributes.GetCronSchedule())
+
+	var continuedAsNew *shared.HistoryEvent
+	for iter.HasNext() {
+		event, err := iter.Next()
+		ts.NoError(err)
+		if event.GetEventType() == shared.EventTypeWorkflowExecutionContinuedAsNew {
+			continuedAsNew = event
+			break
+		}
+	}
+	ts.NotNil(continuedAsNew)
+	secondRunID := continuedAsNew.WorkflowExecutionContinuedAsNewEventAttributes.GetNewExecutionRunId()
+	ts.NotEmpty(secondRunID)
+
+	iter = ts.libClient.GetWorkflowHistory(ctx, wfID, secondRunID, false, shared.HistoryEventFilterTypeAllEvent)
+	ts.True(iter.HasNext())
+	started, err = iter.Next()
+	ts.NoError(err)
+	ts.Equal(shared.EventTypeWorkflowExecutionStarted, started.GetEventType())
+	ts.Empty(started.WorkflowExecutionStartedEventAttributes.GetCronSchedule())
+}
+
 func (ts *IntegrationTestSuite) TestCancellation() {
 	ctx, cancel := context.WithTimeout(context.Background(), ctxTimeout)
 	defer cancel()

--- a/test/workflow_test.go
+++ b/test/workflow_test.go
@@ -238,43 +238,28 @@ func (w *Workflows) ContinueAsNewWithOptions(ctx workflow.Context, count int, ta
 	return "", workflow.NewContinueAsNewError(ctx, w.ContinueAsNewWithOptions, count-1, taskList)
 }
 
-func (w *Workflows) ContinueAsNewWithCronSchedule(ctx workflow.Context, remaining int, taskList, cron string) (string, error) {
-	info := workflow.GetInfo(ctx)
-	if info.TaskListName != taskList {
-		return "", fmt.Errorf("invalid taskListName name, expected=%v, got=%v", taskList, info.TaskListName)
-	}
+// rareCronSchedule fires at midnight on January 1st. The workflows below use it so tests can
+// assert on the schedule recorded in history without a scheduled run ever starting.
+const rareCronSchedule = "0 0 1 1 *"
 
-	var got string
-	if info.CronSchedule != nil {
-		got = *info.CronSchedule
-	}
+// frequentCronSchedule is for workflows that must actually be started by cron. The five field
+// syntax is minute-granular, so its first run would not begin for up to a minute, while this
+// descriptor form is accepted by the same parser and starts a run within seconds.
+const frequentCronSchedule = "@every 1s"
 
-	if remaining == 0 {
-		return got, nil
+// ContinueAsNewWithCronSchedule is can pass its own cron schedule with continue as new.
+func (w *Workflows) ContinueAsNewWithCronSchedule(ctx workflow.Context) (string, error) {
+	if got := w.cronSchedule(ctx); got != "" {
+		ctx = workflow.WithCronSchedule(ctx, rareCronSchedule)
 	}
-
-	ctx = workflow.WithTaskList(ctx, taskList)
-	ctx = workflow.WithCronSchedule(ctx, cron)
-	return "", workflow.NewContinueAsNewError(ctx, w.ContinueAsNewWithCronSchedule, remaining-1, taskList, cron)
+	return "", workflow.NewContinueAsNewError(ctx, w.ContinueAsNewWithCronSchedule)
 }
 
-func (w *Workflows) ContinueAsNewWithoutCronSchedule(ctx workflow.Context, remaining int, taskList string) (string, error) {
-	info := workflow.GetInfo(ctx)
-	if info.TaskListName != taskList {
-		return "", fmt.Errorf("invalid taskListName name, expected=%v, got=%v", taskList, info.TaskListName)
-	}
-
-	var got string
-	if info.CronSchedule != nil {
-		got = *info.CronSchedule
-	}
-
-	if remaining == 0 {
-		return got, nil
-	}
-
-	ctx = workflow.WithTaskList(ctx, taskList)
-	return "", workflow.NewContinueAsNewError(ctx, w.ContinueAsNewWithoutCronSchedule, remaining-1, taskList)
+// ContinueAsNewWithoutCronSchedule continues as new without passing on the cron schedule its
+// own run was started with. The run it continues into reports the schedule it sees, which is
+// empty because cron is not inherited.
+func (w *Workflows) ContinueAsNewWithoutCronSchedule(ctx workflow.Context) (string, error) {
+	return "", workflow.NewContinueAsNewError(ctx, w.ContinueAsNewWithoutCronSchedule)
 }
 
 func (w *Workflows) IDReusePolicy(
@@ -366,23 +351,37 @@ func (w *Workflows) ChildWorkflowSuccess(ctx workflow.Context) (result string, e
 	return
 }
 
-func (w *Workflows) ChildWorkflowsWithCronSchedule(ctx workflow.Context, childID, cron string) (string, error) {
-	ctx = workflow.WithCronSchedule(ctx, cron)
+// ChildWorkflowsWithCronSchedule starts a child on a cron schedule and returns its run ID.
+// A cron child never reports completion to its parent because every run of it continues as
+// new on the schedule, so this only waits for the child to start.
+func (w *Workflows) ChildWorkflowsWithCronSchedule(ctx workflow.Context, childID string) (string, error) {
+	ctx = workflow.WithCronSchedule(ctx, rareCronSchedule)
 	ctx = workflow.WithChildOptions(ctx, workflow.ChildWorkflowOptions{
 		WorkflowID:                   childID,
 		TaskStartToCloseTimeout:      5 * time.Second,
 		ExecutionStartToCloseTimeout: 10 * time.Second,
+		WorkflowIDReusePolicy:        client.WorkflowIDReusePolicyAllowDuplicate,
 	})
-	var result string
-	err := workflow.ExecuteChildWorkflow(ctx, w.childReportsCron).Get(ctx, &result)
-	return result, err
+	var childWE workflow.Execution
+	err := workflow.ExecuteChildWorkflow(ctx, w.childReportsCron).GetChildWorkflowExecution().Get(ctx, &childWE)
+	return childWE.RunID, err
 }
 
+// ChildWorkflowsWithoutWithCronSchedule starts a child from a run that itself has a cron
+// schedule, without calling WithCronSchedule. The first run only exists to give the second
+// one a schedule, since a run started with cron options would not begin until its next
+// scheduled time.
 func (w *Workflows) ChildWorkflowsWithoutWithCronSchedule(ctx workflow.Context, childID string) (string, error) {
+	if w.cronSchedule(ctx) == "" {
+		ctx = workflow.WithCronSchedule(ctx, rareCronSchedule)
+		return "", workflow.NewContinueAsNewError(ctx, w.ChildWorkflowsWithoutWithCronSchedule, childID)
+	}
+
 	ctx = workflow.WithChildOptions(ctx, workflow.ChildWorkflowOptions{
 		WorkflowID:                   childID,
 		TaskStartToCloseTimeout:      5 * time.Second,
 		ExecutionStartToCloseTimeout: 10 * time.Second,
+		WorkflowIDReusePolicy:        client.WorkflowIDReusePolicyAllowDuplicate,
 	})
 	var result string
 	err := workflow.ExecuteChildWorkflow(ctx, w.childReportsCron).Get(ctx, &result)
@@ -390,11 +389,14 @@ func (w *Workflows) ChildWorkflowsWithoutWithCronSchedule(ctx workflow.Context, 
 }
 
 func (w *Workflows) childReportsCron(ctx workflow.Context) (string, error) {
-	info := workflow.GetInfo(ctx)
-	if info.CronSchedule == nil {
-		return "", nil
+	return w.cronSchedule(ctx), nil
+}
+
+func (w *Workflows) cronSchedule(ctx workflow.Context) string {
+	if cron := workflow.GetInfo(ctx).CronSchedule; cron != nil {
+		return *cron
 	}
-	return *info.CronSchedule, nil
+	return ""
 }
 
 func (w *Workflows) ChildWorkflowSuccessWithParentClosePolicyTerminate(ctx workflow.Context) (result string, err error) {

--- a/test/workflow_test.go
+++ b/test/workflow_test.go
@@ -238,6 +238,45 @@ func (w *Workflows) ContinueAsNewWithOptions(ctx workflow.Context, count int, ta
 	return "", workflow.NewContinueAsNewError(ctx, w.ContinueAsNewWithOptions, count-1, taskList)
 }
 
+func (w *Workflows) ContinueAsNewWithCronSchedule(ctx workflow.Context, remaining int, taskList, cron string) (string, error) {
+	info := workflow.GetInfo(ctx)
+	if info.TaskListName != taskList {
+		return "", fmt.Errorf("invalid taskListName name, expected=%v, got=%v", taskList, info.TaskListName)
+	}
+
+	var got string
+	if info.CronSchedule != nil {
+		got = *info.CronSchedule
+	}
+
+	if remaining == 0 {
+		return got, nil
+	}
+
+	ctx = workflow.WithTaskList(ctx, taskList)
+	ctx = workflow.WithCronSchedule(ctx, cron)
+	return "", workflow.NewContinueAsNewError(ctx, w.ContinueAsNewWithCronSchedule, remaining-1, taskList, cron)
+}
+
+func (w *Workflows) ContinueAsNewWithoutCronSchedule(ctx workflow.Context, remaining int, taskList string) (string, error) {
+	info := workflow.GetInfo(ctx)
+	if info.TaskListName != taskList {
+		return "", fmt.Errorf("invalid taskListName name, expected=%v, got=%v", taskList, info.TaskListName)
+	}
+
+	var got string
+	if info.CronSchedule != nil {
+		got = *info.CronSchedule
+	}
+
+	if remaining == 0 {
+		return got, nil
+	}
+
+	ctx = workflow.WithTaskList(ctx, taskList)
+	return "", workflow.NewContinueAsNewError(ctx, w.ContinueAsNewWithoutCronSchedule, remaining-1, taskList)
+}
+
 func (w *Workflows) IDReusePolicy(
 	ctx workflow.Context,
 	childWFID string,
@@ -688,6 +727,8 @@ func (w *Workflows) register(worker worker.Worker) {
 	worker.RegisterWorkflow(w.ActivityRetryOptionsChange)
 	worker.RegisterWorkflow(w.ContinueAsNew)
 	worker.RegisterWorkflow(w.ContinueAsNewWithOptions)
+	worker.RegisterWorkflow(w.ContinueAsNewWithCronSchedule)
+	worker.RegisterWorkflow(w.ContinueAsNewWithoutCronSchedule)
 	worker.RegisterWorkflow(w.IDReusePolicy)
 	worker.RegisterWorkflow(w.ChildWorkflowRetryOnError)
 	worker.RegisterWorkflow(w.ChildWorkflowRetryOnTimeout)

--- a/test/workflow_test.go
+++ b/test/workflow_test.go
@@ -366,6 +366,37 @@ func (w *Workflows) ChildWorkflowSuccess(ctx workflow.Context) (result string, e
 	return
 }
 
+func (w *Workflows) ChildWorkflowsWithCronSchedule(ctx workflow.Context, childID, cron string) (string, error) {
+	ctx = workflow.WithCronSchedule(ctx, cron)
+	ctx = workflow.WithChildOptions(ctx, workflow.ChildWorkflowOptions{
+		WorkflowID:                   childID,
+		TaskStartToCloseTimeout:      5 * time.Second,
+		ExecutionStartToCloseTimeout: 10 * time.Second,
+	})
+	var result string
+	err := workflow.ExecuteChildWorkflow(ctx, w.childReportsCron).Get(ctx, &result)
+	return result, err
+}
+
+func (w *Workflows) ChildWorkflowsWithoutWithCronSchedule(ctx workflow.Context, childID string) (string, error) {
+	ctx = workflow.WithChildOptions(ctx, workflow.ChildWorkflowOptions{
+		WorkflowID:                   childID,
+		TaskStartToCloseTimeout:      5 * time.Second,
+		ExecutionStartToCloseTimeout: 10 * time.Second,
+	})
+	var result string
+	err := workflow.ExecuteChildWorkflow(ctx, w.childReportsCron).Get(ctx, &result)
+	return result, err
+}
+
+func (w *Workflows) childReportsCron(ctx workflow.Context) (string, error) {
+	info := workflow.GetInfo(ctx)
+	if info.CronSchedule == nil {
+		return "", nil
+	}
+	return *info.CronSchedule, nil
+}
+
 func (w *Workflows) ChildWorkflowSuccessWithParentClosePolicyTerminate(ctx workflow.Context) (result string, err error) {
 	opts := workflow.ChildWorkflowOptions{
 		TaskStartToCloseTimeout:      5 * time.Second,
@@ -736,6 +767,9 @@ func (w *Workflows) register(worker worker.Worker) {
 	worker.RegisterWorkflow(w.ChildWorkflowSuccessWithParentClosePolicyTerminate)
 	worker.RegisterWorkflow(w.ChildWorkflowSuccessWithParentClosePolicyAbandon)
 	worker.RegisterWorkflow(w.ChildWorkflowCancel)
+	worker.RegisterWorkflow(w.ChildWorkflowsWithCronSchedule)
+	worker.RegisterWorkflow(w.ChildWorkflowsWithoutWithCronSchedule)
+	worker.RegisterWorkflow(w.childReportsCron)
 	worker.RegisterWorkflow(w.InspectActivityInfo)
 	worker.RegisterWorkflow(w.InspectLocalActivityInfo)
 	worker.RegisterWorkflow(w.sleep)

--- a/workflow/error.go
+++ b/workflow/error.go
@@ -110,11 +110,13 @@ type (
 // the new execution with same workflow ID is started automatically with options
 // provided to this function.
 //
-//	 ctx - use context to override any options for the new workflow like execution timeout, decision task timeout, task list.
-//		  if not mentioned it would use the defaults that the current workflow is using.
+//	 ctx - use context to override any options for the new workflow like execution timeout, decision task timeout, task list, cron schedule.
+//		  if not mentioned it would use the defaults that the current workflow is using
+//		  (except cron schedule, which is not inherited; use WithCronSchedule to keep it).
 //	       ctx := WithExecutionStartToCloseTimeout(ctx, 30 * time.Minute)
 //	       ctx := WithWorkflowTaskStartToCloseTimeout(ctx, time.Minute)
 //		  ctx := WithWorkflowTaskList(ctx, "example-group")
+//		  ctx := WithCronSchedule(ctx, "* * * * *")
 //	 wfn - workflow function. for new execution it can be different from the currently running.
 //	 args - arguments for the new workflow.
 func NewContinueAsNewError(ctx Context, wfn interface{}, args ...interface{}) *ContinueAsNewError {

--- a/workflow/workflow_options.go
+++ b/workflow/workflow_options.go
@@ -42,6 +42,24 @@ func WithWorkflowTaskList(ctx Context, name string) Context {
 	return internal.WithWorkflowTaskList(ctx, name)
 }
 
+// WithCronSchedule sets a cron schedule on the context for ContinueAsNew and child workflows.
+//
+// Cron is not inherited from the current run. Pass it explicitly when the next
+// execution should keep a schedule, for example:
+//
+//	info := workflow.GetInfo(ctx)
+//	if info.CronSchedule != nil {
+//		ctx = workflow.WithCronSchedule(ctx, *info.CronSchedule)
+//	}
+//	return workflow.NewContinueAsNewError(ctx, myWorkflow, args...)
+//
+// The same option is read by ExecuteChildWorkflow. WithChildOptions overwrites
+// CronSchedule from ChildWorkflowOptions; call WithCronSchedule after
+// WithChildOptions if both are used. Omit it (or pass "") to start a non-cron run.
+func WithCronSchedule(ctx Context, cronSchedule string) Context {
+	return internal.WithCronSchedule(ctx, cronSchedule)
+}
+
 // GetWorkflowTaskList returns tasklist in the Context's current ChildWorkflowOptions
 // or workflow.GetInfo(ctx).TaskListName if not set or empty.
 func GetWorkflowTaskList(ctx Context) string {

--- a/workflow/workflow_options.go
+++ b/workflow/workflow_options.go
@@ -53,9 +53,9 @@ func WithWorkflowTaskList(ctx Context, name string) Context {
 //	}
 //	return workflow.NewContinueAsNewError(ctx, myWorkflow, args...)
 //
-// The same option is read by ExecuteChildWorkflow. WithChildOptions overwrites
-// CronSchedule from ChildWorkflowOptions; call WithCronSchedule after
-// WithChildOptions if both are used. Omit it (or pass "") to start a non-cron run.
+// The same option is read by ExecuteChildWorkflow. WithChildOptions copies
+// CronSchedule only when it is non-empty, so WithCronSchedule then
+// WithChildOptions still keeps the schedule. Pass "" here to start a non-cron run.
 func WithCronSchedule(ctx Context, cronSchedule string) Context {
 	return internal.WithCronSchedule(ctx, cronSchedule)
 }


### PR DESCRIPTION

<!-- Describe what has changed in this PR -->
**What changed?**

By design, cron schedule is not inherited on explicit ContinueAsNew as well as child workflow. However, there are use cases that need it.

* add WithCronSchedule API
* the same field in the workflow options will be used by child workflow as well. 


<!-- Tell your future self why have you made these changes -->
**Why?**
Ref [#1394 ](https://github.com/cadence-workflow/cadence/issues/1394)

A workflow with cron schedule may receive a signal to change the input for the future runs or even change the cron schedule. This was not possible before because ContinueAsNew error doesn't propagate cron schedule at all. 

To be backward compatible, we need to ask users to explicitly use WithCronSchedule API to inject the cron schedule into the context so they can return a custom ContinueAsNewError to change the cron schedule or the input. 


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

Unit Test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

**Detailed Description**
[In-depth description of the changes made to the interfaces, specifying new fields, removed fields, or modified data structures]

**Impact Analysis**
- **Backward Compatibility**: Yes, new API that doesn't change existing behavior
- **Forward Compatibility**: Yes

**Testing Plan**
- **Unit Tests**: Yes
- **Persistence Tests**: No
- **Integration Tests**: No
- **Compatibility Tests**: No

**Rollout Plan**
- What is the rollout plan? New API usage
- Does the order of deployment matter? No
- Is it safe to rollback? Does the order of rollback matter? No, new API users will get errors
- Is there a kill switch to mitigate the impact immediately? No
