### PR TITLE
fix: reschedule decision task with pending local activity on worker shutdown

### DIFF
--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -816,6 +816,18 @@ func (wth *workflowTaskHandlerImpl) ProcessWorkflowTask(
 		workflowContext.Unlock(errRet)
 	}()
 
+	// laStopCh is closed when the worker starts shutting down. At that point the
+	// local activity pool stops accepting tasks, so a pending local activity (and
+	// any retry) can no longer be dispatched and its result will never arrive.
+	// Without this signal the loop below would keep heartbeating the decision task
+	// until the server's decisionHeartbeatTimeout (default 30m). laTunnel is nil
+	// during history replay (no worker); a nil channel never selects, leaving the
+	// replay path unchanged.
+	var laStopCh <-chan struct{}
+	if workflowContext.laTunnel != nil {
+		laStopCh = workflowContext.laTunnel.stopCh
+	}
+
 	var response interface{}
 process_Workflow_Loop:
 	for {
@@ -827,6 +839,13 @@ process_Workflow_Loop:
 				deadlineToTrigger := time.Duration(float32(ratioToForceCompleteDecisionTaskComplete) * float32(workflowContext.GetDecisionTimeout()))
 				delayDuration := startTime.Add(deadlineToTrigger).Sub(time.Now())
 				select {
+				case <-laStopCh:
+					// Worker is shutting down and the pending local activity can no
+					// longer be dispatched. Abandon this decision task so the server
+					// reschedules it on a healthy worker, instead of holding it open
+					// until decisionHeartbeatTimeout.
+					return nil, &decisionHeartbeatError{Message: "worker is shutting down with a pending local activity; abandoning decision task for reschedule"}
+
 				case <-time.After(delayDuration):
 					// force complete, call the decision heartbeat function
 					workflowTask, err = heartbeatFunc(

--- a/internal/internal_task_handlers_test.go
+++ b/internal/internal_task_handlers_test.go
@@ -1293,6 +1293,78 @@ func (t *TaskHandlersTestSuite) TestLocalActivityRetry_DecisionHeartbeatFail() {
 	<-doneCh
 }
 
+func (t *TaskHandlersTestSuite) TestLocalActivity_WorkerShutdownAbandonsDecisionTask() {
+	// Once the worker starts shutting down, a pending local activity can no longer
+	// be dispatched and its result will never arrive. The decision task must be
+	// abandoned (surfaced as a decisionHeartbeatError so the poller lets the server
+	// reschedule it) instead of heartbeating until the server's
+	// decisionHeartbeatTimeout.
+	localActivityWorkflowFunc := func(ctx Context, input []byte) error {
+		ctx = WithLocalActivityOptions(ctx, LocalActivityOptions{ScheduleToCloseTimeout: time.Minute})
+		return ExecuteLocalActivity(ctx, func() error { return nil }).Get(ctx, nil)
+	}
+	t.registry.RegisterWorkflowWithOptions(
+		localActivityWorkflowFunc,
+		RegisterWorkflowOptions{Name: "ShutdownLocalActivityWorkflow"},
+	)
+
+	// A long decision timeout ensures the heartbeat branch cannot fire during the
+	// test, so the only way the loop returns is via the worker-shutdown branch.
+	decisionTaskStartedEvent := createTestEventDecisionTaskStarted(3)
+	decisionTaskStartedEvent.Timestamp = common.Int64Ptr(time.Now().UnixNano())
+	testEvents := []*s.HistoryEvent{
+		createTestEventWorkflowExecutionStarted(1, &s.WorkflowExecutionStartedEventAttributes{
+			TaskStartToCloseTimeoutSeconds: common.Int32Ptr(60),
+			TaskList:                       &s.TaskList{Name: &testWorkflowTaskTasklist},
+		}),
+		createTestEventDecisionTaskScheduled(2, &s.DecisionTaskScheduledEventAttributes{}),
+		decisionTaskStartedEvent,
+	}
+	task := createWorkflowTask(testEvents, 0, "ShutdownLocalActivityWorkflow")
+
+	stopCh := make(chan struct{})
+	params := workerExecutionParameters{
+		TaskList:          &s.TaskList{Name: common.StringPtr("taskList"), Kind: s.TaskListKindNormal.Ptr()},
+		WorkerOptions:     WorkerOptions{Identity: "test-id-1", Logger: t.logger},
+		WorkerStopChannel: stopCh,
+	}
+
+	taskHandler := newWorkflowTaskHandler(testDomain, params, nil, t.registry)
+	taskHandlerImpl, ok := taskHandler.(*workflowTaskHandlerImpl)
+	t.True(ok)
+	taskHandlerImpl.laTunnel = newLocalActivityTunnel(params.WorkerStopChannel)
+
+	type processResult struct {
+		response interface{}
+		err      error
+	}
+	resultCh := make(chan processResult, 1)
+	go func() {
+		response, err := taskHandler.ProcessWorkflowTask(
+			&workflowTask{task: task, laResultCh: make(chan *localActivityResult)},
+			func(interface{}, time.Time) (*workflowTask, error) {
+				return nil, errors.New("heartbeat must not be called on shutdown")
+			},
+		)
+		resultCh <- processResult{response, err}
+	}()
+
+	// Let the workflow dispatch the local activity and enter the wait loop while
+	// the worker is still healthy, then signal shutdown.
+	time.Sleep(100 * time.Millisecond)
+	close(stopCh)
+
+	select {
+	case r := <-resultCh:
+		t.Nil(r.response)
+		var hbErr *decisionHeartbeatError
+		t.True(errors.As(r.err, &hbErr))
+		t.Contains(r.err.Error(), "shutting down")
+	case <-time.After(5 * time.Second):
+		t.Fail("ProcessWorkflowTask did not return after worker shutdown")
+	}
+}
+
 func (t *TaskHandlersTestSuite) TestHeartBeat_NoError() {
 	mockCtrl := gomock.NewController(t.T())
 	mockService := workflowservicetest.NewMockClient(mockCtrl)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
on worker shutdown, ProcessWorkflowTask now watches the local-activity tunnel stop channel in the decision wait loop and returns a decisionHeartbeatError, letting the poller reschedule the decision task on a healthy worker.

<!-- Tell your future self why have you made these changes -->
**Why?**
once the worker starts shutting down, the local-activity pool stops accepting tasks, so a pending local activity (and its retry) can no longer be dispatched and its result never arrives. The loop would otherwise keep decision-heartbeating until the server's decisionHeartbeatTimeout (default 30m), stalling work such as schedule-triggered workflow starts.


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Added TestLocalActivity_WorkerShutdownAbandonsDecisionTask: dispatches a pending local activity, closes the worker stop channel, and asserts ProcessWorkflowTask returns a decisionHeartbeatError promptly. Passes under -race; full TaskHandlersTestSuite green; gofmt clean.


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
on graceful shutdown an in-flight local activity is abandoned and re-run after reschedule; safe for idempotent activities (LA results are markers, scheduled starts dedupe via deterministic RequestID). No normal-path impact: the new branch only fires on shutdown, and laTunnel is nil during replay so a nil channel never selects.
