### PR TITLE
feat(workflow): allow setting request ID in start workflow options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-- Added RequestID (`uuid.UUID`) to StartWorkflowOptions so start and signal-with-start requests can supply an idempotency key instead of always generating a new UUID. The server only accepts UUID strings.
+- Added RequestID to StartWorkflowOptions so start and signal-with-start requests can supply an idempotency key instead of always generating a new UUID. The value must be a UUID string; the client validates it before sending.
 
 ### Fixed
 - Skip seeding the workflow span context when the tracer is a `NoopTracer`, preventing panics for workflow tests that mix the testsuite (which defaults to `NoopTracer`) with a real tracer such as `mocktracer`. Follow-up to the span activation added in #1506 and the `NoopTracer` guard in #1516.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Added RequestID (`uuid.UUID`) to StartWorkflowOptions so start and signal-with-start requests can supply an idempotency key instead of always generating a new UUID. The server only accepts UUID strings.
+
 ### Fixed
 - Skip seeding the workflow span context when the tracer is a `NoopTracer`, preventing panics for workflow tests that mix the testsuite (which defaults to `NoopTracer`) with a real tracer such as `mocktracer`. Follow-up to the span activation added in #1506 and the `NoopTracer` guard in #1516.
 

--- a/internal/client.go
+++ b/internal/client.go
@@ -27,7 +27,6 @@ import (
 	"time"
 
 	"github.com/opentracing/opentracing-go"
-	"github.com/pborman/uuid"
 	"github.com/uber-go/tally"
 	"go.uber.org/zap"
 
@@ -429,19 +428,19 @@ type (
 
 		// RequestID - Unique identifier for this start request. Used for idempotency so retries of the
 		// same start or signal-with-start call do not create duplicate executions.
-		// Must be a UUID; the server rejects other strings.
+		// Must be a UUID string; the client rejects other values before sending the request.
 		// Optional: defaulted to a generated UUID.
 		//
 		// To derive a RequestID deterministically from a business string, use a name-based UUID
 		// (RFC 4122 version 5). The same namespace and name always produce the same UUID:
 		//
 		//   ns := uuid.Parse("6ba7b812-9dad-11d1-80b4-00c04fd430c8") // or uuid.NameSpace_OID
-		//   options.RequestID = uuid.NewSHA1(ns, []byte("order-123:start"))
+		//   options.RequestID = uuid.NewSHA1(ns, []byte("order-123:start")).String()
 		//
 		// Prefer a stable, service-specific namespace UUID so names do not collide with UUIDs
 		// generated for other purposes. Do not hash the business string with SHA-1/MD5 and
-		// format it yourself; only RFC 4122 UUID strings are accepted by the server.
-		RequestID uuid.UUID
+		// format it yourself; only RFC 4122 UUID strings are accepted.
+		RequestID string
 
 		// TaskList - The decisions of the workflow are scheduled on this queue.
 		// This is also the default task list on which activities are scheduled. The workflow author can choose

--- a/internal/client.go
+++ b/internal/client.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"github.com/opentracing/opentracing-go"
+	"github.com/pborman/uuid"
 	"github.com/uber-go/tally"
 	"go.uber.org/zap"
 
@@ -425,6 +426,22 @@ type (
 		// ID - The business identifier of the workflow execution.
 		// Optional: defaulted to a uuid.
 		ID string
+
+		// RequestID - Unique identifier for this start request. Used for idempotency so retries of the
+		// same start or signal-with-start call do not create duplicate executions.
+		// Must be a UUID; the server rejects other strings.
+		// Optional: defaulted to a generated UUID.
+		//
+		// To derive a RequestID deterministically from a business string, use a name-based UUID
+		// (RFC 4122 version 5). The same namespace and name always produce the same UUID:
+		//
+		//   ns := uuid.Parse("6ba7b812-9dad-11d1-80b4-00c04fd430c8") // or uuid.NameSpace_OID
+		//   options.RequestID = uuid.NewSHA1(ns, []byte("order-123:start"))
+		//
+		// Prefer a stable, service-specific namespace UUID so names do not collide with UUIDs
+		// generated for other purposes. Do not hash the business string with SHA-1/MD5 and
+		// format it yourself; only RFC 4122 UUID strings are accepted by the server.
+		RequestID uuid.UUID
 
 		// TaskList - The decisions of the workflow are scheduled on this queue.
 		// This is also the default task list on which activities are scheduled. The workflow author can choose

--- a/internal/internal_workflow_client.go
+++ b/internal/internal_workflow_client.go
@@ -1148,7 +1148,7 @@ func (wc *workflowClient) getWorkflowStartRequest(
 	// run propagators to extract information about tracing and other stuff, store in headers field
 	startRequest := &s.StartWorkflowExecutionRequest{
 		Domain:                              common.StringPtr(wc.domain),
-		RequestId:                           common.StringPtr(uuid.New()),
+		RequestId:                           common.StringPtr(requestIDOrNew(options.RequestID)),
 		WorkflowId:                          common.StringPtr(workflowID),
 		WorkflowType:                        workflowTypePtr(*workflowType),
 		TaskList:                            common.TaskListPtr(s.TaskList{Name: common.StringPtr(options.TaskList)}),
@@ -1255,7 +1255,7 @@ func (wc *workflowClient) getSignalWithStartRequest(
 
 	signalWithStartRequest := &s.SignalWithStartWorkflowExecutionRequest{
 		Domain:                              common.StringPtr(wc.domain),
-		RequestId:                           common.StringPtr(uuid.New()),
+		RequestId:                           common.StringPtr(requestIDOrNew(options.RequestID)),
 		WorkflowId:                          common.StringPtr(workflowID),
 		WorkflowType:                        workflowTypePtr(*workflowType),
 		TaskList:                            common.TaskListPtr(s.TaskList{Name: common.StringPtr(options.TaskList)}),
@@ -1287,6 +1287,13 @@ func getRunID(runID string) *string {
 		return nil
 	}
 	return common.StringPtr(runID)
+}
+
+func requestIDOrNew(requestID uuid.UUID) string {
+	if len(requestID) == 0 {
+		return uuid.New()
+	}
+	return requestID.String()
 }
 
 func (iter *historyEventIteratorImpl) HasNext() bool {

--- a/internal/internal_workflow_client.go
+++ b/internal/internal_workflow_client.go
@@ -1093,6 +1093,10 @@ func (wc *workflowClient) getWorkflowStartRequest(
 		decisionTaskTimeout = defaultDecisionTaskTimeoutInSecs
 	}
 
+	if err := validateRequestID(options.RequestID); err != nil {
+		return nil, err
+	}
+
 	// Validate type and its arguments.
 	workflowType, input, err := getValidatedWorkflowFunction(workflowFunc, args, wc.dataConverter, wc.registry)
 	if err != nil {
@@ -1207,6 +1211,10 @@ func (wc *workflowClient) getSignalWithStartRequest(
 		decisionTaskTimeout = defaultDecisionTaskTimeoutInSecs
 	}
 
+	if err := validateRequestID(options.RequestID); err != nil {
+		return nil, err
+	}
+
 	// Validate type and its arguments.
 	workflowType, input, err := getValidatedWorkflowFunction(workflowFunc, workflowArgs, wc.dataConverter, wc.registry)
 	if err != nil {
@@ -1294,6 +1302,17 @@ func requestIDOrNew(requestID uuid.UUID) string {
 		return uuid.New()
 	}
 	return requestID.String()
+}
+
+func validateRequestID(requestID uuid.UUID) error {
+	if len(requestID) == 0 {
+		return nil
+	}
+	// pborman UUID is a []byte; only a 16-byte value formats as a UUID string.
+	if uuid.Parse(requestID.String()) == nil {
+		return errors.New("invalid RequestID")
+	}
+	return nil
 }
 
 func (iter *historyEventIteratorImpl) HasNext() bool {

--- a/internal/internal_workflow_client.go
+++ b/internal/internal_workflow_client.go
@@ -1297,19 +1297,18 @@ func getRunID(runID string) *string {
 	return common.StringPtr(runID)
 }
 
-func requestIDOrNew(requestID uuid.UUID) string {
-	if len(requestID) == 0 {
+func requestIDOrNew(requestID string) string {
+	if requestID == "" {
 		return uuid.New()
 	}
-	return requestID.String()
+	return requestID
 }
 
-func validateRequestID(requestID uuid.UUID) error {
-	if len(requestID) == 0 {
+func validateRequestID(requestID string) error {
+	if requestID == "" {
 		return nil
 	}
-	// pborman UUID is a []byte; only a 16-byte value formats as a UUID string.
-	if uuid.Parse(requestID.String()) == nil {
+	if uuid.Parse(requestID) == nil {
 		return errors.New("invalid RequestID")
 	}
 	return nil

--- a/internal/internal_workflow_client_test.go
+++ b/internal/internal_workflow_client_test.go
@@ -2934,6 +2934,18 @@ func TestGetWorkflowStartRequest(t *testing.T) {
 			},
 		},
 		{
+			name: "invalid RequestID",
+			options: StartWorkflowOptions{
+				ID:                              workflowID,
+				RequestID:                       uuid.UUID("not-a-uuid"),
+				TaskList:                        tasklist,
+				ExecutionStartToCloseTimeout:    10 * time.Second,
+				DecisionTaskStartToCloseTimeout: 5 * time.Second,
+			},
+			workflowFunc: func(ctx Context) {},
+			wantErr:      "invalid RequestID",
+		},
+		{
 			name: "missing TaskList",
 			options: StartWorkflowOptions{
 				ID:                              workflowID,
@@ -3104,6 +3116,20 @@ func TestGetSignalWithStartRequest(t *testing.T) {
 				WorkflowIdReusePolicy:               shared.WorkflowIdReusePolicyAllowDuplicateFailedOnly.Ptr(),
 				CronOverlapPolicy:                   shared.CronOverlapPolicySkipped.Ptr(),
 			},
+		},
+		{
+			name:       "invalid RequestID",
+			workflowID: workflowID,
+			signalName: "signal",
+			options: StartWorkflowOptions{
+				ID:                              workflowID,
+				RequestID:                       uuid.UUID("not-a-uuid"),
+				TaskList:                        tasklist,
+				ExecutionStartToCloseTimeout:    10 * time.Second,
+				DecisionTaskStartToCloseTimeout: 5 * time.Second,
+			},
+			workflowFunc: func(ctx Context) {},
+			wantErr:      "invalid RequestID",
 		},
 		{
 			name: "first run at negative",

--- a/internal/internal_workflow_client_test.go
+++ b/internal/internal_workflow_client_test.go
@@ -2903,6 +2903,37 @@ func TestGetWorkflowStartRequest(t *testing.T) {
 			},
 		},
 		{
+			name: "with RequestID",
+			options: StartWorkflowOptions{
+				ID:                              workflowID,
+				RequestID:                       uuid.Parse("550e8400-e29b-41d4-a716-446655440000"),
+				TaskList:                        tasklist,
+				ExecutionStartToCloseTimeout:    10 * time.Second,
+				DecisionTaskStartToCloseTimeout: 5 * time.Second,
+			},
+			workflowFunc: func(ctx Context) {},
+			wantRequest: &shared.StartWorkflowExecutionRequest{
+				Domain:     common.StringPtr(domain),
+				RequestId:  common.StringPtr("550e8400-e29b-41d4-a716-446655440000"),
+				WorkflowId: common.StringPtr(workflowID),
+				WorkflowType: &shared.WorkflowType{
+					Name: common.StringPtr("go.uber.org/cadence/internal.TestGetWorkflowStartRequest.func2"),
+				},
+				TaskList: &shared.TaskList{
+					Name: common.StringPtr(tasklist),
+				},
+				ExecutionStartToCloseTimeoutSeconds: common.Int32Ptr(10),
+				TaskStartToCloseTimeoutSeconds:      common.Int32Ptr(5),
+				DelayStartSeconds:                   common.Int32Ptr(0),
+				JitterStartSeconds:                  common.Int32Ptr(0),
+				FirstRunAtTimestamp:                 common.Int64Ptr(0),
+				CronSchedule:                        common.StringPtr(""),
+				Header:                              &shared.Header{Fields: map[string][]byte{}},
+				WorkflowIdReusePolicy:               shared.WorkflowIdReusePolicyAllowDuplicateFailedOnly.Ptr(),
+				CronOverlapPolicy:                   shared.CronOverlapPolicySkipped.Ptr(),
+			},
+		},
+		{
 			name: "missing TaskList",
 			options: StartWorkflowOptions{
 				ID:                              workflowID,
@@ -3018,7 +3049,9 @@ func TestGetWorkflowStartRequest(t *testing.T) {
 
 			// set the randomized fields in the expected request before comparison
 			tc.wantRequest.Identity = &wc.identity
-			tc.wantRequest.RequestId = gotReq.RequestId
+			if tc.wantRequest.RequestId == nil {
+				tc.wantRequest.RequestId = gotReq.RequestId
+			}
 
 			assert.Equal(t, tc.wantRequest, gotReq)
 		})
@@ -3037,6 +3070,41 @@ func TestGetSignalWithStartRequest(t *testing.T) {
 		wantRequest  *shared.SignalWithStartWorkflowExecutionRequest
 		wantErr      string
 	}{
+		{
+			name:       "with RequestID",
+			workflowID: workflowID,
+			signalName: "signal",
+			options: StartWorkflowOptions{
+				ID:                              workflowID,
+				RequestID:                       uuid.Parse("550e8400-e29b-41d4-a716-446655440000"),
+				TaskList:                        tasklist,
+				ExecutionStartToCloseTimeout:    10 * time.Second,
+				DecisionTaskStartToCloseTimeout: 5 * time.Second,
+			},
+			workflowFunc: func(ctx Context) {},
+			wantRequest: &shared.SignalWithStartWorkflowExecutionRequest{
+				Domain:     common.StringPtr(domain),
+				RequestId:  common.StringPtr("550e8400-e29b-41d4-a716-446655440000"),
+				WorkflowId: common.StringPtr(workflowID),
+				WorkflowType: &shared.WorkflowType{
+					Name: common.StringPtr("go.uber.org/cadence/internal.TestGetSignalWithStartRequest.func1"),
+				},
+				TaskList: &shared.TaskList{
+					Name: common.StringPtr(tasklist),
+				},
+				ExecutionStartToCloseTimeoutSeconds: common.Int32Ptr(10),
+				TaskStartToCloseTimeoutSeconds:      common.Int32Ptr(5),
+				SignalName:                          common.StringPtr("signal"),
+				SignalInput:                         []byte("null\n"),
+				DelayStartSeconds:                   common.Int32Ptr(0),
+				JitterStartSeconds:                  common.Int32Ptr(0),
+				FirstRunAtTimestamp:                 common.Int64Ptr(0),
+				CronSchedule:                        common.StringPtr(""),
+				Header:                              &shared.Header{Fields: map[string][]byte{}},
+				WorkflowIdReusePolicy:               shared.WorkflowIdReusePolicyAllowDuplicateFailedOnly.Ptr(),
+				CronOverlapPolicy:                   shared.CronOverlapPolicySkipped.Ptr(),
+			},
+		},
 		{
 			name: "first run at negative",
 			options: StartWorkflowOptions{
@@ -3074,7 +3142,9 @@ func TestGetSignalWithStartRequest(t *testing.T) {
 
 			// set the randomized fields in the expected request before comparison
 			tc.wantRequest.Identity = &wc.identity
-			tc.wantRequest.RequestId = gotReq.RequestId
+			if tc.wantRequest.RequestId == nil {
+				tc.wantRequest.RequestId = gotReq.RequestId
+			}
 
 			assert.Equal(t, tc.wantRequest, gotReq)
 		})

--- a/internal/internal_workflow_client_test.go
+++ b/internal/internal_workflow_client_test.go
@@ -2906,7 +2906,7 @@ func TestGetWorkflowStartRequest(t *testing.T) {
 			name: "with RequestID",
 			options: StartWorkflowOptions{
 				ID:                              workflowID,
-				RequestID:                       uuid.Parse("550e8400-e29b-41d4-a716-446655440000"),
+				RequestID:                       "550e8400-e29b-41d4-a716-446655440000",
 				TaskList:                        tasklist,
 				ExecutionStartToCloseTimeout:    10 * time.Second,
 				DecisionTaskStartToCloseTimeout: 5 * time.Second,
@@ -2937,7 +2937,7 @@ func TestGetWorkflowStartRequest(t *testing.T) {
 			name: "invalid RequestID",
 			options: StartWorkflowOptions{
 				ID:                              workflowID,
-				RequestID:                       uuid.UUID("not-a-uuid"),
+				RequestID:                       "not-a-uuid",
 				TaskList:                        tasklist,
 				ExecutionStartToCloseTimeout:    10 * time.Second,
 				DecisionTaskStartToCloseTimeout: 5 * time.Second,
@@ -3088,7 +3088,7 @@ func TestGetSignalWithStartRequest(t *testing.T) {
 			signalName: "signal",
 			options: StartWorkflowOptions{
 				ID:                              workflowID,
-				RequestID:                       uuid.Parse("550e8400-e29b-41d4-a716-446655440000"),
+				RequestID:                       "550e8400-e29b-41d4-a716-446655440000",
 				TaskList:                        tasklist,
 				ExecutionStartToCloseTimeout:    10 * time.Second,
 				DecisionTaskStartToCloseTimeout: 5 * time.Second,
@@ -3123,7 +3123,7 @@ func TestGetSignalWithStartRequest(t *testing.T) {
 			signalName: "signal",
 			options: StartWorkflowOptions{
 				ID:                              workflowID,
-				RequestID:                       uuid.UUID("not-a-uuid"),
+				RequestID:                       "not-a-uuid",
 				TaskList:                        tasklist,
 				ExecutionStartToCloseTimeout:    10 * time.Second,
 				DecisionTaskStartToCloseTimeout: 5 * time.Second,


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

Allow client users to set request ID in the start workflow requests and signalwithstart requests. 

<!-- Tell your future self why have you made these changes -->
**Why?**

Duplicate request can cause unnecessary retries and timeout. With request ID dedup, we can safely ack the request with better performance. 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

Unit Test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
